### PR TITLE
Rename CameraSerialNumberManager to CameraSerialResolver

### DIFF
--- a/Facett/BLEManager.swift
+++ b/Facett/BLEManager.swift
@@ -2330,7 +2330,7 @@ class BLEManager: NSObject, ObservableObject, CBCentralManagerDelegate, CBPeriph
 
         // Convert serials to UUIDs
         let cameraIds = cameraSerials.compactMap { serial -> UUID? in
-            return CameraSerialNumberManager.shared.getUUID(forSerial: serial)
+            return CameraSerialResolver.shared.getUUID(forSerial: serial)
         }
 
         let cameraCount = cameraIds.count
@@ -2357,7 +2357,7 @@ class BLEManager: NSObject, ObservableObject, CBCentralManagerDelegate, CBPeriph
     func startRecordingForCamerasInSet(_ cameraSerials: Set<String>) {
         // Convert serial numbers to UUIDs
         let cameraIds = cameraSerials.compactMap { serial -> UUID? in
-            return CameraSerialNumberManager.shared.getUUID(forSerial: serial)
+            return CameraSerialResolver.shared.getUUID(forSerial: serial)
         }
         recordingManager.startRecordingForCamerasInSet(Set(cameraIds))
     }
@@ -2365,7 +2365,7 @@ class BLEManager: NSObject, ObservableObject, CBCentralManagerDelegate, CBPeriph
     func stopRecordingForCamerasInSet(_ cameraSerials: Set<String>) {
         // Convert serial numbers to UUIDs
         let cameraIds = cameraSerials.compactMap { serial -> UUID? in
-            return CameraSerialNumberManager.shared.getUUID(forSerial: serial)
+            return CameraSerialResolver.shared.getUUID(forSerial: serial)
         }
         recordingManager.stopRecordingForCamerasInSet(Set(cameraIds))
     }

--- a/Facett/BLEResponseHandler.swift
+++ b/Facett/BLEResponseHandler.swift
@@ -323,7 +323,7 @@ class BLEResponseHandler {
     /// Handle serial number update from apSSID - store mapping
     private func handleSerialNumberUpdate(ssid: String, uuid: UUID) {
         // Store the serial number mapping for lookup
-        CameraSerialNumberManager.shared.storeUUID(uuid, forSerial: ssid)
+        CameraSerialResolver.shared.storeUUID(uuid, forSerial: ssid)
 
         // Store the display name mapping using serial number
         if let gopro = bleManager?.connectedGoPros[uuid],

--- a/Facett/CameraGroup.swift
+++ b/Facett/CameraGroup.swift
@@ -20,7 +20,7 @@ struct CameraGroup: Identifiable, Codable {
     /// Helper to get current UUIDs for all cameras in this group
     var cameraIds: Set<UUID> {
         Set(cameraSerials.compactMap { serial in
-            CameraSerialNumberManager.shared.getUUID(forSerial: serial)
+            CameraSerialResolver.shared.getUUID(forSerial: serial)
         })
     }
 }

--- a/Facett/CameraGroupViewComponents.swift
+++ b/Facett/CameraGroupViewComponents.swift
@@ -97,7 +97,7 @@ struct CameraInGroupRowView: View {
     let onRemove: () -> Void
 
     private var cameraId: UUID? {
-        CameraSerialNumberManager.shared.getUUID(forSerial: cameraSerial)
+        CameraSerialResolver.shared.getUUID(forSerial: cameraSerial)
     }
 
     private func getCameraName() -> String {

--- a/Facett/CameraIdentityManager.swift
+++ b/Facett/CameraIdentityManager.swift
@@ -97,9 +97,9 @@ class CameraIdentityManager: ObservableObject {
     }
 }
 
-// MARK: - Camera Serial Number Manager
-class CameraSerialNumberManager {
-    static let shared = CameraSerialNumberManager()
+// MARK: - Camera Serial Resolver
+class CameraSerialResolver {
+    static let shared = CameraSerialResolver()
 
     private let persistenceManager = DataPersistenceManager.shared
     private let serialToUUIDKey = "CameraSerialToUUID"

--- a/Facett/CameraViews.swift
+++ b/Facett/CameraViews.swift
@@ -363,7 +363,7 @@ struct ActiveGroupSummaryView: View {
 
         for serial in set.cameraSerials {
             // Look up the current UUID for this serial number
-            guard let cameraId = CameraSerialNumberManager.shared.getUUID(forSerial: serial) else {
+            guard let cameraId = CameraSerialResolver.shared.getUUID(forSerial: serial) else {
                 continue
             }
 
@@ -406,7 +406,7 @@ struct ActiveGroupSummaryView: View {
                 GridItem(.flexible())
             ], spacing: 8) {
                 ForEach(Array(set.cameraSerials).sorted(), id: \.self) { (serial: String) in
-                    if let cameraId = CameraSerialNumberManager.shared.getUUID(forSerial: serial) {
+                    if let cameraId = CameraSerialResolver.shared.getUUID(forSerial: serial) {
                         if let connectedCamera = bleManager.connectedGoPros[cameraId] {
                             // Camera is fully connected - show full status
                             CameraStatusCardView(

--- a/Facett/ContentView.swift
+++ b/Facett/ContentView.swift
@@ -43,7 +43,7 @@ struct ContentView: View {
 
         if let activeGroup = cameraGroupManager.activeGroup {
             camerasToCheck = activeGroup.cameraSerials.compactMap { serial in
-                guard let uuid = CameraSerialNumberManager.shared.getUUID(forSerial: serial) else { return nil }
+                guard let uuid = CameraSerialResolver.shared.getUUID(forSerial: serial) else { return nil }
                 return bleManager.connectedGoPros[uuid]
             }
         } else {


### PR DESCRIPTION
## Summary

- Rename `CameraSerialNumberManager` → `CameraSerialResolver` across 7 files (11 call sites)
- Aligns with the `CameraIdentity*` naming convention used by the file it lives in (`CameraIdentityManager.swift`)
- Updated MARK comment

## Test plan

- [x] Build succeeds
- [x] No remaining references to old name

Closes #1

Made with [Cursor](https://cursor.com)