### PR TITLE
Add SwiftLint with baseline configuration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: SwiftLint
+        run: |
+          brew install swiftlint
+          swiftlint lint --strict
+
       - name: List available simulators
         run: xcrun simctl list devices available | head -30
 

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,45 @@
+excluded:
+  - Facett/LaunchScreen.storyboard
+
+line_length:
+  warning: 300
+  error: 400
+
+file_length:
+  warning: 2500
+  error: 3500
+
+type_body_length:
+  warning: 1700
+  error: 2500
+
+function_body_length:
+  warning: 300
+  error: 500
+
+cyclomatic_complexity:
+  warning: 120
+  error: 150
+
+large_tuple:
+  warning: 4
+  error: 6
+
+identifier_name:
+  min_length: 1
+
+disabled_rules:
+  - duplicate_conditions
+  - for_where
+  - implicit_optional_initialization
+  - multiple_closures_with_trailing_closure
+  - nesting
+  - opening_brace
+  - orphaned_doc_comment
+  - redundant_discardable_let
+  - static_over_final_class
+  - trailing_semicolon
+  - unneeded_synthesized_initializer
+  - unused_closure_parameter
+  - unused_optional_binding
+  - vertical_whitespace


### PR DESCRIPTION
## Summary

- Add `.swiftlint.yml` tuned to the project's current code style
- Add SwiftLint step to CI workflow (runs before build)
- 0 violations with current config — thresholds can be tightened over time

### Disabled rules (existing code conflicts)
`duplicate_conditions`, `for_where`, `implicit_optional_initialization`, `multiple_closures_with_trailing_closure`, `nesting`, `opening_brace`, `orphaned_doc_comment`, `redundant_discardable_let`, `static_over_final_class`, `trailing_semicolon`, `unneeded_synthesized_initializer`, `unused_closure_parameter`, `unused_optional_binding`, `vertical_whitespace`

### Relaxed thresholds
Line length (300/400), file length (2500/3500), type body (1700/2500), function body (300/500), cyclomatic complexity (120/150)

## Test plan

- [x] `swiftlint lint --strict` passes with 0 violations
- [x] Build succeeds

Closes #8

Made with [Cursor](https://cursor.com)