### PR TITLE
Fix camera group sheet dismissal, activeGroupId persistence, and force unwraps

### DIFF
--- a/Facett/CameraGroup.swift
+++ b/Facett/CameraGroup.swift
@@ -189,7 +189,9 @@ class CameraGroupManager: ObservableObject {
     func removeCameraGroup(_ group: CameraGroup) {
         cameraGroups.removeAll { $0.id == group.id }
         if activeGroupId == group.id {
-            activeGroupId = cameraGroups.first?.id
+            let newActiveId = cameraGroups.first?.id
+            activeGroupId = newActiveId
+            userDefaults.set(newActiveId?.uuidString, forKey: activeGroupKey)
         }
         saveCameraGroups()
     }

--- a/Facett/CameraGroupManagementViews.swift
+++ b/Facett/CameraGroupManagementViews.swift
@@ -54,7 +54,10 @@ struct CameraGroupManagementView: View {
                     group: group,
                     cameraGroupManager: cameraGroupManager,
                     bleManager: bleManager,
-                    isPresented: .constant(true)
+                    isPresented: Binding(
+                        get: { selectedGroupForEdit != nil },
+                        set: { if !$0 { selectedGroupForEdit = nil } }
+                    )
                 )
             }
         }

--- a/Facett/RecordingControlsView.swift
+++ b/Facett/RecordingControlsView.swift
@@ -13,10 +13,12 @@ struct RecordingControlsView: View {
     @State private var previouslyAllOnlineAndInSync = false
 
     private var isAnyCameraRecording: Bool {
-        let cameras = cameraGroupManager.activeGroup != nil ?
-            cameraGroupManager.activeGroup!.cameraIds.compactMap { bleManager.connectedGoPros[$0] } :
-            Array(bleManager.connectedGoPros.values)
-
+        let cameras: [GoPro]
+        if let activeGroup = cameraGroupManager.activeGroup {
+            cameras = activeGroup.cameraIds.compactMap { bleManager.connectedGoPros[$0] }
+        } else {
+            cameras = Array(bleManager.connectedGoPros.values)
+        }
         return cameras.contains { $0.status.isEncoding == true }
     }
 
@@ -78,10 +80,12 @@ struct RecordingControlsView: View {
     }
 
     private var recordingCameraCount: Int {
-        let cameras = cameraGroupManager.activeGroup != nil ?
-            cameraGroupManager.activeGroup!.cameraIds.compactMap { bleManager.connectedGoPros[$0] } :
-            Array(bleManager.connectedGoPros.values)
-
+        let cameras: [GoPro]
+        if let activeGroup = cameraGroupManager.activeGroup {
+            cameras = activeGroup.cameraIds.compactMap { bleManager.connectedGoPros[$0] }
+        } else {
+            cameras = Array(bleManager.connectedGoPros.values)
+        }
         return cameras.filter { $0.status.isEncoding == true }.count
     }
 
@@ -259,12 +263,11 @@ struct RecordingControlsView: View {
             HStack(spacing: 8) {
                 // Connect All Button
                 Button(action: {
-                    if cameraGroupManager.activeGroup != nil {
-                        // Connect cameras in active group
-                        let cameraIds = Set(cameraGroupManager.activeGroup!.cameraIds)
+                    if let activeGroup = cameraGroupManager.activeGroup {
+                        let cameraIds = Set(activeGroup.cameraIds)
                         bleManager.setTargetCameras(cameraIds)
 
-                        for cameraId in cameraGroupManager.activeGroup!.cameraIds {
+                        for cameraId in activeGroup.cameraIds {
                             if bleManager.discoveredGoPros[cameraId] != nil {
                                 bleManager.connectToGoPro(uuid: cameraId)
                             }
@@ -292,14 +295,12 @@ struct RecordingControlsView: View {
 
                 // Disconnect All Button
                 Button(action: {
-                    if cameraGroupManager.activeGroup != nil {
-                        // Disconnect cameras in active group
-                        for cameraId in cameraGroupManager.activeGroup!.cameraIds {
+                    if let activeGroup = cameraGroupManager.activeGroup {
+                        for cameraId in activeGroup.cameraIds {
                             if bleManager.connectedGoPros[cameraId] != nil {
                                 bleManager.disconnectFromGoPro(uuid: cameraId)
                             }
                         }
-                        // Clear target cameras for this group
                         bleManager.clearTargetCameras()
                     } else {
                         // Disconnect all cameras
@@ -325,9 +326,8 @@ struct RecordingControlsView: View {
 
                 // Sleep All Button
                 Button(action: {
-                    if cameraGroupManager.activeGroup != nil {
-                        // Sleep cameras in active group
-                        for cameraId in cameraGroupManager.activeGroup!.cameraIds {
+                    if let activeGroup = cameraGroupManager.activeGroup {
+                        for cameraId in activeGroup.cameraIds {
                             if bleManager.connectedGoPros[cameraId] != nil {
                                 bleManager.disconnectFromGoPro(uuid: cameraId, sleep: true)
                             }


### PR DESCRIPTION
Fixes #22, #23

## Summary
- **Sheet dismissal (#22):** Editor sheet passed `isPresented: .constant(true)`, so the Save button could never dismiss it. Now uses a computed binding that clears `selectedGroupForEdit`.
- **activeGroupId persistence (#23):** `removeCameraGroup` updated `activeGroupId` in memory but only persisted the groups array. After restart, `activeGroupId` pointed to a deleted group. Now also persists to UserDefaults.
- **Force unwraps (#23):** Replaced all `activeGroup!` force unwraps in `RecordingControlsView` with optional binding to prevent crashes when `activeGroup` is nil.

## Test plan
- [x] Builds cleanly
- [ ] Verify editor sheet dismisses when Save is tapped
- [ ] Delete the active group, restart app, verify no crash and a valid group is selected
- [ ] Verify Connect/Disconnect/Sleep buttons work with active group

Made with [Cursor](https://cursor.com)