### PR TITLE
Fix BLE timer retain cycles and performance monitor force unwraps

### DIFF
--- a/Facett/BLEManager.swift
+++ b/Facett/BLEManager.swift
@@ -220,9 +220,8 @@ class BLEManager: NSObject, ObservableObject, CBCentralManagerDelegate, CBPeriph
         }
         pendingCommands[uuid]?.append(pendingCommand)
 
-        // Set up timeout timer
-        DispatchQueue.main.asyncAfter(deadline: .now() + timeout) {
-            self.handleCommandTimeout(for: uuid, command: command, commandName: commandName)
+        DispatchQueue.main.asyncAfter(deadline: .now() + timeout) { [weak self] in
+            self?.handleCommandTimeout(for: uuid, command: command, commandName: commandName)
         }
     }
 
@@ -259,9 +258,8 @@ class BLEManager: NSObject, ObservableObject, CBCentralManagerDelegate, CBPeriph
 
             pendingCommands[uuid]?.append(retryCommand)
 
-            // Retry the command
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
-                self.sendCommand(command, to: uuid, commandName: commandName, requiresControl: pendingCommand.requiresControl)
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak self] in
+                self?.sendCommand(command, to: uuid, commandName: commandName, requiresControl: pendingCommand.requiresControl)
             }
         } else {
             log("❌ Command '\(commandName)' failed after \(commandRetryAttempts) attempts")
@@ -636,6 +634,13 @@ class BLEManager: NSObject, ObservableObject, CBCentralManagerDelegate, CBPeriph
     deinit {
         stopDeviceQueryTimer()
         stopDeviceScanTimer()
+        stopStragglerRetryTimer()
+        connectionRetryTimers.values.forEach { $0.invalidate() }
+        connectionRetryTimers.removeAll()
+        connectionAttemptTimers.values.forEach { $0.invalidate() }
+        connectionAttemptTimers.removeAll()
+        commandQueueTimers.values.forEach { $0.invalidate() }
+        commandQueueTimers.removeAll()
     }
 
     /// Logs items with a timestamp, similar to `print`.
@@ -911,8 +916,8 @@ class BLEManager: NSObject, ObservableObject, CBCentralManagerDelegate, CBPeriph
                     }
 
                     // Schedule retry after exponential backoff delay
-                    self.connectionRetryTimers[uuid] = Timer.scheduledTimer(withTimeInterval: retryDelay, repeats: false) { _ in
-                        self.retryConnection(for: uuid)
+                    self.connectionRetryTimers[uuid] = Timer.scheduledTimer(withTimeInterval: retryDelay, repeats: false) { [weak self] _ in
+                        self?.retryConnection(for: uuid)
                     }
                 } else {
                     // Max retries reached, give up
@@ -1241,8 +1246,8 @@ class BLEManager: NSObject, ObservableObject, CBCentralManagerDelegate, CBPeriph
 
         // Force a settings query to get the updated state
         // This ensures the camera's settings are properly reflected in the UI
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-            self.queryAllSettings(from: peripheral)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+            self?.queryAllSettings(from: peripheral)
         }
     }
 
@@ -1369,10 +1374,9 @@ class BLEManager: NSObject, ObservableObject, CBCentralManagerDelegate, CBPeriph
         // Clear any pending commands for this device
         pendingCommands[uuid]?.removeAll()
 
-        // Wait a moment then attempt to reconnect
-        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
-            self.log("🔄 Attempting to reconnect after authentication error...")
-            self.centralManager.connect(peripheral, options: nil)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) { [weak self] in
+            self?.log("🔄 Attempting to reconnect after authentication error...")
+            self?.centralManager.connect(peripheral, options: nil)
         }
     }
 
@@ -1855,8 +1859,8 @@ class BLEManager: NSObject, ObservableObject, CBCentralManagerDelegate, CBPeriph
             self.connectingGoPros[uuid] = gopro // Add to connecting list
 
             // Set up connection timeout for retry attempt
-            self.connectionAttemptTimers[uuid] = Timer.scheduledTimer(withTimeInterval: self.connectionTimeout, repeats: false) { _ in
-                self.handleConnectionTimeout(for: uuid)
+            self.connectionAttemptTimers[uuid] = Timer.scheduledTimer(withTimeInterval: self.connectionTimeout, repeats: false) { [weak self] _ in
+                self?.handleConnectionTimeout(for: uuid)
             }
         }
         centralManager.connect(gopro.peripheral, options: nil)

--- a/Facett/BLEPerformanceMonitor.swift
+++ b/Facett/BLEPerformanceMonitor.swift
@@ -124,10 +124,7 @@ class BLEPerformanceMonitor: ObservableObject {
     /// Record command start time
     func recordCommandStart(for uuid: UUID, commandName: String) -> Date {
         let startTime = Date()
-        if commandStartTimes[uuid] == nil {
-            commandStartTimes[uuid] = [:]
-        }
-        commandStartTimes[uuid]![commandName] = startTime
+        commandStartTimes[uuid, default: [:]][commandName] = startTime
         return startTime
     }
 
@@ -135,12 +132,7 @@ class BLEPerformanceMonitor: ObservableObject {
     func recordCommandCompletion(for uuid: UUID, commandName: String, startTime: Date, success: Bool, retryCount: Int = 0) {
         let responseTime = Date().timeIntervalSince(startTime)
 
-        // Update performance metrics
-        if performanceMetrics[uuid] == nil {
-            performanceMetrics[uuid] = PerformanceMetrics()
-        }
-
-        var metrics = performanceMetrics[uuid]!
+        var metrics = performanceMetrics[uuid] ?? PerformanceMetrics()
         metrics.totalCommands += 1
         metrics.totalResponseTime += responseTime
         metrics.averageResponseTime = metrics.totalResponseTime / Double(metrics.totalCommands)
@@ -171,22 +163,13 @@ class BLEPerformanceMonitor: ObservableObject {
 
     /// Record disconnection
     func recordDisconnection(for uuid: UUID) {
-        if connectionHealth[uuid] == nil {
-            connectionHealth[uuid] = ConnectionHealth()
-        }
-
-        var health = connectionHealth[uuid]!
+        var health = connectionHealth[uuid] ?? ConnectionHealth()
         health.disconnectionCount += 1
         health.lastDisconnection = Date()
         health.stabilityScore = max(0, health.stabilityScore - 0.1)
         connectionHealth[uuid] = health
 
-        // Update connection stability
-        if connectionStability[uuid] == nil {
-            connectionStability[uuid] = ConnectionStability()
-        }
-
-        var stability = connectionStability[uuid]!
+        var stability = connectionStability[uuid] ?? ConnectionStability()
         stability.totalConnections += 1
         stability.failedConnections += 1
         connectionStability[uuid] = stability
@@ -194,22 +177,13 @@ class BLEPerformanceMonitor: ObservableObject {
 
     /// Record successful connection
     func recordSuccessfulConnection(for uuid: UUID) {
-        if connectionStability[uuid] == nil {
-            connectionStability[uuid] = ConnectionStability()
-        }
-
-        var stability = connectionStability[uuid]!
+        var stability = connectionStability[uuid] ?? ConnectionStability()
         stability.totalConnections += 1
         stability.successfulConnections += 1
         stability.lastConnectionAttempt = Date()
         connectionStability[uuid] = stability
 
-        // Improve health score
-        if connectionHealth[uuid] == nil {
-            connectionHealth[uuid] = ConnectionHealth()
-        }
-
-        var health = connectionHealth[uuid]!
+        var health = connectionHealth[uuid] ?? ConnectionHealth()
         health.stabilityScore = min(1.0, health.stabilityScore + 0.05)
         connectionHealth[uuid] = health
     }
@@ -257,11 +231,7 @@ class BLEPerformanceMonitor: ObservableObject {
     // MARK: - Private Methods
 
     private func updateConnectionHealth(for uuid: UUID, responseTime: CommandResponseTime) {
-        if connectionHealth[uuid] == nil {
-            connectionHealth[uuid] = ConnectionHealth()
-        }
-
-        var health = connectionHealth[uuid]!
+        var health = connectionHealth[uuid] ?? ConnectionHealth()
 
         // Update average response time
         if health.averageResponseTime == 0 {


### PR DESCRIPTION
Fixes #24, #25

## Summary
**BLEManager timer retain cycles (#24):**
- Added `[weak self]` to all timer and asyncAfter closures that captured `self` strongly (command timeout, retry, connection retry/attempt, settings query, auth reconnect)
- Added cleanup of all timer dictionaries in `deinit` — previously only `deviceQueryTimer` and `deviceScanTimer` were invalidated

**BLEPerformanceMonitor force unwraps (#25):**
- Replaced all init-then-force-unwrap patterns (`performanceMetrics[uuid]!`, `connectionHealth[uuid]!`, `connectionStability[uuid]!`, `commandStartTimes[uuid]!`) with nil-coalescing defaults to prevent crashes from concurrent access

## Test plan
- [x] Builds cleanly
- [ ] Verify BLE connection/disconnection cycles don't leak memory
- [ ] Verify performance metrics still update correctly

Made with [Cursor](https://cursor.com)