### PR TITLE
Fix minor bugs: duplicate ConfigManager, redundant haptics, fragile split, assert

### DIFF
--- a/Facett/BLEManager.swift
+++ b/Facett/BLEManager.swift
@@ -978,8 +978,7 @@ class BLEManager: NSObject, ObservableObject, CBCentralManagerDelegate, CBPeriph
 
         // Ensure characteristic value exists
         guard let data = characteristic.value else {
-            assert(false, "Characteristic value should not be nil")
-            log("No data received for \(characteristic.uuid).")
+            ErrorHandler.error("Characteristic value unexpectedly nil", context: ["uuid": characteristic.uuid.uuidString])
             return
         }
 

--- a/Facett/BLEPacketReconstructor.swift
+++ b/Facett/BLEPacketReconstructor.swift
@@ -78,10 +78,8 @@ class BLEPacketReconstructor {
                 ErrorHandler.warning("Timeout detected for buffer", context: ["buffer_key": bufferKey])
 
                 if let buffer = continuationBuffer[bufferKey] {
-                    // Extract query ID from buffer key
-                    let queryIDString = bufferKey.split(separator: ":")[1]
-                    let queryID = UInt8(queryIDString) ?? 0
-
+                    let parts = bufferKey.split(separator: ":")
+                    let queryID = parts.count >= 2 ? (UInt8(parts[1]) ?? 0) : 0
                     results.append((data: buffer, queryID: queryID))
                 }
 

--- a/Facett/BLERecordingManager.swift
+++ b/Facett/BLERecordingManager.swift
@@ -156,15 +156,6 @@ class BLERecordingManager {
 
         bleManager.log("🎥 Sending recording command: \(commandName) to \(uuid)")
 
-        // Provide haptic feedback for recording start/stop
-        DispatchQueue.main.async {
-            if commandName.contains("start") {
-                self.recordingStartedHaptic()
-            } else {
-                self.recordingStoppedHaptic()
-            }
-        }
-
         let command: [UInt8] = [3, 1, 1, commandName.contains("start") ? 1 : 0]
         bleManager.log("📤 Recording command bytes: \(command.map { String(format: "0x%02X", $0) }.joined(separator: " "))")
 

--- a/Facett/FacettApp.swift
+++ b/Facett/FacettApp.swift
@@ -5,7 +5,7 @@ struct FacettApp: App {
     @Environment(\.scenePhase) private var scenePhase
 
     @StateObject var bleManager = BLEManager()
-    @StateObject var configManager = ConfigManager()
+    @StateObject var configManager: ConfigManager
     @StateObject var cameraGroupManager: CameraGroupManager
 
     init() {


### PR DESCRIPTION
Partially addresses #29

## Summary
- **FacettApp:** `@StateObject var configManager = ConfigManager()` created a second ConfigManager that was immediately overwritten in `init`. Removed the default initializer.
- **BLERecordingManager:** `sendRecordingCommand` triggered haptic feedback per-camera, on top of the batch-level haptic in `startRecordingForCamerasInSet`. Removed the per-command haptic.
- **BLEPacketReconstructor:** `checkTimeouts` used `bufferKey.split(separator: ":")[1]` which crashes if the key has no `:`. Now guards the index access.
- **BLEManager:** Replaced `assert(false, ...)` (stripped in release) with `ErrorHandler.error()` so the failure is actually logged in production.

## Test plan
- [x] Builds cleanly
- [ ] Verify recording haptics fire once per action, not per camera
- [ ] Verify app launches without duplicate ConfigManager warnings

Made with [Cursor](https://cursor.com)