### PR TITLE
Clean up BLE state on disconnect: timers, queues, pending commands, parser buffers

### DIFF
--- a/Facett/BLEConnectionHandler.swift
+++ b/Facett/BLEConnectionHandler.swift
@@ -54,21 +54,22 @@ class BLEConnectionHandler {
         let uuid = peripheral.identifier
         ErrorHandler.info("\(CameraIdentityManager.shared.getDisplayName(for: uuid, currentName: peripheral.name)) disconnected.")
 
+        bleManager.cleanupDeviceState(for: uuid)
+
         DispatchQueue.main.async {
-            // Check if device was intentionally put to sleep - don't move to discovered list if so
             let isSleeping = bleManager.isDeviceSleeping(uuid)
 
             if let gopro = bleManager.connectedGoPros[uuid] {
                 bleManager.connectedGoPros.removeValue(forKey: uuid)
                 if !isSleeping {
-                    bleManager.discoveredGoPros[uuid] = gopro // Move back to discovered list only if not sleeping
+                    bleManager.discoveredGoPros[uuid] = gopro
                 } else {
                     ErrorHandler.info("🌙 \(CameraIdentityManager.shared.getDisplayName(for: uuid, currentName: peripheral.name)) is sleeping - not moving to discovered list")
                 }
             } else if let gopro = bleManager.connectingGoPros[uuid] {
                 bleManager.connectingGoPros.removeValue(forKey: uuid)
                 if !isSleeping {
-                    bleManager.discoveredGoPros[uuid] = gopro // Move back to discovered list only if not sleeping
+                    bleManager.discoveredGoPros[uuid] = gopro
                 } else {
                     ErrorHandler.info("🌙 \(CameraIdentityManager.shared.getDisplayName(for: uuid, currentName: peripheral.name)) is sleeping - not moving to discovered list")
                 }

--- a/Facett/BLEManager.swift
+++ b/Facett/BLEManager.swift
@@ -633,6 +633,26 @@ class BLEManager: NSObject, ObservableObject, CBCentralManagerDelegate, CBPeriph
         }
     }
 
+    /// Clean up all state associated with a disconnected device
+    func cleanupDeviceState(for uuid: UUID) {
+        connectionRetryTimers[uuid]?.invalidate()
+        connectionRetryTimers.removeValue(forKey: uuid)
+
+        connectionAttemptTimers[uuid]?.invalidate()
+        connectionAttemptTimers.removeValue(forKey: uuid)
+
+        commandQueueTimers[uuid]?.invalidate()
+        commandQueueTimers.removeValue(forKey: uuid)
+
+        commandQueues.removeValue(forKey: uuid)
+        pendingCommands.removeValue(forKey: uuid)
+        connectionRetryCount.removeValue(forKey: uuid)
+
+        bleParser.clearBuffers(for: uuid.uuidString)
+
+        performanceMonitor.recordDisconnection(for: uuid)
+    }
+
     deinit {
         stopDeviceQueryTimer()
         stopDeviceScanTimer()

--- a/Facett/BLEPacketReconstructor.swift
+++ b/Facett/BLEPacketReconstructor.swift
@@ -60,6 +60,16 @@ class BLEPacketReconstructor {
         lastPacketTime.removeAll()
     }
 
+    /// Clear buffers for a specific peripheral
+    func clearBuffers(for peripheralId: String) {
+        let keysToRemove = continuationBuffer.keys.filter { $0.hasPrefix(peripheralId) }
+        for key in keysToRemove {
+            continuationBuffer.removeValue(forKey: key)
+            expectedMessageLength.removeValue(forKey: key)
+            lastPacketTime.removeValue(forKey: key)
+        }
+    }
+
     /// Get current buffer state (useful for testing)
     func getBufferState() -> (buffers: [String: Data], expectedLengths: [String: Int]) {
         return (continuationBuffer, expectedMessageLength)

--- a/Facett/BLEParser.swift
+++ b/Facett/BLEParser.swift
@@ -318,6 +318,11 @@ class GoProBLEParser {
         packetReconstructor.clearBuffers()
     }
 
+    /// Clear buffers for a specific peripheral
+    func clearBuffers(for peripheralId: String) {
+        packetReconstructor.clearBuffers(for: peripheralId)
+    }
+
     /// Get current buffer state (useful for testing)
     func getBufferState() -> (buffers: [String: Data], expectedLengths: [String: Int]) {
         return packetReconstructor.getBufferState()


### PR DESCRIPTION
Fixes #17

## Summary
On disconnect, BLEManager now cleans up all per-device state via `cleanupDeviceState(for:)`:
- Invalidates and removes `connectionRetryTimers`, `connectionAttemptTimers`, and `commandQueueTimers`
- Clears `commandQueues` and `pendingCommands` to stop retries/timeouts from running against a gone device
- Clears `connectionRetryCount`
- Clears parser reconstruction buffers for the specific peripheral (new `clearBuffers(for:)` API)
- Calls `performanceMonitor.recordDisconnection()` which was previously never invoked

## Test plan
- [x] Builds cleanly
- [ ] Connect/disconnect a camera and verify no orphaned timer activity in console
- [ ] Verify reconnection still works after disconnect
- [ ] Verify command queue restarts fresh on reconnection

Made with [Cursor](https://cursor.com)