### PR TITLE
Match BLE responses to pending commands by command type instead of FIFO

### DIFF
--- a/Facett/BLEManager.swift
+++ b/Facett/BLEManager.swift
@@ -231,6 +231,16 @@ class BLEManager: NSObject, ObservableObject, CBCentralManagerDelegate, CBPeriph
         pendingCommands[uuid]?.removeAll { $0.command == command }
     }
 
+    /// Find and remove the first pending command matching a response command type
+    private func removeMatchingPendingCommand(responseCommandType: UInt8, from uuid: UUID) {
+        guard let pendingList = pendingCommands[uuid] else { return }
+        if let match = pendingList.first(where: { $0.command.count > 1 && $0.command[1] == responseCommandType }) {
+            removePendingCommand(match.command, from: uuid)
+        } else if let first = pendingList.first {
+            removePendingCommand(first.command, from: uuid)
+        }
+    }
+
     /// Handle command timeout
     private func handleCommandTimeout(for uuid: UUID, command: [UInt8], commandName: String) {
         guard let pendingCommandList = pendingCommands[uuid],
@@ -1087,9 +1097,8 @@ class BLEManager: NSObject, ObservableObject, CBCentralManagerDelegate, CBPeriph
 
         // First, check for special 5-byte responses (claim control, turbo enable/disable, etc.).
         if handleFiveByteResponse(data, for: peripheral) {
-            // Remove any pending commands since we got a response
-            if let pendingCommandList = pendingCommands[uuid], let firstCommand = pendingCommandList.first {
-                removePendingCommand(firstCommand.command, from: uuid)
+            if data.count > 1 {
+                removeMatchingPendingCommand(responseCommandType: data[1], from: uuid)
             }
             return
         }
@@ -1171,10 +1180,7 @@ class BLEManager: NSObject, ObservableObject, CBCentralManagerDelegate, CBPeriph
             log("Command response error for \(cameraName). Command type: \(commandType).")
         }
 
-        // Remove any pending commands since we got a response
-        if let pendingCommandList = pendingCommands[uuid], let firstCommand = pendingCommandList.first {
-            removePendingCommand(firstCommand.command, from: uuid)
-        }
+        removeMatchingPendingCommand(responseCommandType: commandType, from: uuid)
     }
 
     // MARK: - Handle Special 5-Byte Responses


### PR DESCRIPTION
Fixes #18

## Summary
`handleCommandResponse` previously always removed the **first** pending command when a response arrived, assuming FIFO ordering. BLE responses can arrive out of order, causing wrong command/response pairing, spurious timeouts, and retries of already-completed commands.

Now uses `removeMatchingPendingCommand(responseCommandType:from:)` which matches the response's command type byte (`data[1]`) to a pending command with the same type (`command[1]`). Falls back to FIFO if no type match is found, preserving backward compatibility.

## Test plan
- [x] Builds cleanly
- [ ] Verify commands still complete successfully with single camera
- [ ] Verify multi-camera command sequences don't cause spurious timeouts

Made with [Cursor](https://cursor.com)