### PR TITLE
Fix packet reconstructor buffer selection for concurrent multipart responses

### DIFF
--- a/Facett/BLEPacketReconstructor.swift
+++ b/Facett/BLEPacketReconstructor.swift
@@ -176,16 +176,22 @@ class BLEPacketReconstructor {
             "peripheral_id": peripheralId
         ])
 
-        // Find the buffer for this peripheral (we don't know the query ID yet)
         let bufferKeys = continuationBuffer.keys.filter { $0.hasPrefix(peripheralId) }
 
         if bufferKeys.isEmpty {
-            // This might be the first packet of a multipart response
             return handleFirstPacketOfMultipart(data: data, peripheralId: peripheralId)
         }
 
-        // Track sequence counters for multiple concurrent operations
-        guard let bufferKey = bufferKeys.first else {
+        // When multiple buffers exist, pick the most recently active one.
+        // Continuation packets don't carry a query ID, so we use recency
+        // as the best heuristic. The GoPro BLE protocol expects one
+        // multipart response per characteristic at a time.
+        let bufferKey: String
+        if bufferKeys.count == 1 {
+            bufferKey = bufferKeys[0]
+        } else if let mostRecent = bufferKeys.max(by: { (lastPacketTime[$0] ?? .distantPast) < (lastPacketTime[$1] ?? .distantPast) }) {
+            bufferKey = mostRecent
+        } else {
             ErrorHandler.bleError("No buffer key found for continuation packet", context: ["peripheral_id": peripheralId])
             return nil
         }


### PR DESCRIPTION
Fixes #19

## Summary
When multiple multipart responses were in flight for the same peripheral, continuation packets were routed to an arbitrary buffer (whichever came first in dictionary order). This could mix data from different responses and corrupt parsed results.

Now selects the most recently active buffer by `lastPacketTime`, which is the correct heuristic since the GoPro BLE protocol expects one multipart response per characteristic at a time and continuation packets don't carry a query ID.

## Test plan
- [x] Builds cleanly
- [ ] Verify status queries still parse correctly
- [ ] Verify no data corruption in multi-query scenarios

Made with [Cursor](https://cursor.com)