### PR TITLE
Audit BLE protocol implementation against GoPro Open API spec

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,11 @@ jobs:
             -project Facett.xcodeproj \
             -scheme Facett \
             -destination "platform=iOS Simulator,name=iPhone 16" \
-            -only-testing:FacettTests/ParserTests \
+            -only-testing:FacettTests/PacketReconstructorTests \
+            -only-testing:FacettTests/TLVParserTests \
+            -only-testing:FacettTests/ResponseMapperTests \
+            -only-testing:FacettTests/BLEParserPipelineTests \
+            -only-testing:FacettTests/GoProCommandTests \
             -only-testing:FacettTests/SettingsTests \
+            -only-testing:FacettTests/StateMachineTests \
             -quiet

--- a/BLE_PROTOCOL.md
+++ b/BLE_PROTOCOL.md
@@ -23,53 +23,58 @@ let GoProResponseUUID = CBUUID(string: "B5F90003-AA8D-11E3-9046-0002A5D5C51B")
 
 ## Packet Structure
 
+BLE 4.2 limits packets to 20 bytes. Larger messages are split across start + continuation packets.
+
+Reference: https://gopro.github.io/OpenGoPro/ble/protocol/data_protocol.html
+
 ### Header Format
 
-Every BLE packet starts with a 1-byte header:
+**Bit 7** determines start vs. continuation:
 
+- **Bit 7 = 0 → Start packet.** Bits 6-5 select the length format:
+  - `00` → General (5-bit): bits 4-0 = message length (max 31)
+  - `01` → Extended 13-bit: bits 4-0 + next byte = message length
+  - `10` → Extended 16-bit: next 2 bytes = message length (receive-only)
+- **Bit 7 = 1 → Continuation packet.** Bits 3-0 = 4-bit sequence counter (wraps at 0xF)
+
+### Start Packet Types
+
+#### General (5-bit length)
 ```
-┌─────────┬─────────┬─────────┬─────────┬─────────┬─────────┬─────────┬─────────┐
-│ Bit 7   │ Bit 6   │ Bit 5   │ Bit 4   │ Bit 3   │ Bit 2   │ Bit 1   │ Bit 0   │
-├─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
-│ Packet  │ Packet  │Continu- │ Reserved│ Reserved│ Reserved│ Reserved│ Reserved│
-│ Type    │ Type    │ation    │         │         │         │         │         │
-│ MSB     │ LSB     │ Bit     │         │         │         │         │         │
-└─────────┴─────────┴─────────┴─────────┴─────────┴─────────┴─────────┴─────────┘
-```
-
-**Header Fields**:
-- **Bits 7-6**: Packet Type
-  - `00`: General packet
-  - `01`: Extended packet
-  - `10`: Continuation packet
-  - `11`: Reserved
-- **Bit 5**: Continuation bit (1 = more packets coming)
-- **Bits 4-0**: Reserved (must be 0)
-
-### Packet Types
-
-#### 1. **General Packet (Type 0)**
-```
-┌─────────┬─────────┬─────────┬─────────┬─────────────┐
-│ Header  │ Length  │ QueryID │ Status  │ TLV Data    │
-│ (1 byte)│ (1 byte)│ (1 byte)│ (1 byte)│ (variable)  │
-└─────────┴─────────┴─────────┴─────────┴─────────────┘
+Byte 0:  [0][00][5-bit message length]
+Bytes 1+: message payload
 ```
 
-#### 2. **Extended Packet (Type 1)**
+#### Extended 13-bit
 ```
-┌─────────┬─────────┬─────────┬─────────┬─────────┬─────────────┐
-│ Header  │ Length  │ QueryID │ Status  │ Extended│ TLV Data    │
-│ (1 byte)│ (2 bytes)│ (1 byte)│ (1 byte)│ (2 bytes)│ (variable)  │
-└─────────┴─────────┴─────────┴─────────┴─────────┴─────────────┘
+Byte 0:  [0][01][upper 5 bits of length]
+Byte 1:  [lower 8 bits of length]
+Bytes 2+: message payload
 ```
 
-#### 3. **Continuation Packet (Type 2)**
+#### Extended 16-bit (receive-only, for messages >= 8192 bytes)
 ```
-┌─────────┬─────────────┐
-│ Header  │ TLV Data    │
-│ (1 byte)│ (variable)  │
-└─────────┴─────────────┘
+Byte 0:  [0][10][reserved]
+Byte 1-2: 16-bit message length
+Bytes 3+: message payload
+```
+
+### Continuation Packet
+```
+Byte 0:  [1][reserved][4-bit counter]
+Bytes 1+: continuation payload (appended to accumulated message)
+```
+
+### Message Payload
+
+For query responses (on the Query Response characteristic), the message payload is:
+```
+[QueryID (1 byte)] [Status (1 byte)] [TLV data...]
+```
+
+For command responses (on the Command Response characteristic):
+```
+[CommandID (1 byte)] [Status (1 byte)] [optional response data...]
 ```
 
 ## TLV (Type-Length-Value) Encoding

--- a/Facett/BLEManager.swift
+++ b/Facett/BLEManager.swift
@@ -601,7 +601,6 @@ class BLEManager: NSObject, ObservableObject, CBCentralManagerDelegate, CBPeriph
     }
 
     // Command registry for centralized command management
-    private let commandRegistry = GoProCommandRegistry.shared
 
     override init() {
         super.init()

--- a/Facett/BLEPacketReconstructor.swift
+++ b/Facett/BLEPacketReconstructor.swift
@@ -1,66 +1,47 @@
 import Foundation
 
-/// Handles BLE packet reconstruction for multi-packet messages
+/// Handles BLE packet reconstruction for multi-packet messages per the GoPro Open API spec.
+///
+/// Packet header formats (from https://gopro.github.io/OpenGoPro/ble/protocol/data_protocol.html):
+/// - Bit 7 = 0: Start packet; Bits 6-5 determine format:
+///   - 00: General (5-bit length in bits 4-0)
+///   - 01: Extended 13-bit (bits 4-0 + next byte = 13-bit length)
+///   - 10: Extended 16-bit (next 2 bytes = 16-bit length, receive-only)
+/// - Bit 7 = 1: Continuation packet; Bits 3-0 = 4-bit sequence counter
 class BLEPacketReconstructor {
 
     // MARK: - Properties
 
-    /// Continuation packet buffers for message reconstruction
-    private var continuationBuffer: [String: Data] = [:] // Key: "peripheralID:queryID"
-    private var expectedMessageLength: [String: Int] = [:] // Key: "peripheralID:queryID"
-    private var lastPacketTime: [String: Date] = [:] // Track when last packet was received
+    private var continuationBuffer: [String: Data] = [:]
+    private var expectedMessageLength: [String: Int] = [:]
+    private var lastPacketTime: [String: Date] = [:]
 
     // MARK: - Public Interface
 
-    /// Process a BLE packet and return complete message data if available
-    /// - Parameters:
-    ///   - data: Raw packet data from BLE
-    ///   - peripheralId: Unique identifier for the peripheral
-    /// - Returns: Complete message data if available, nil if message is incomplete
+    /// Process a BLE packet and return complete message data if available.
+    /// Returns the TLV payload and query/command ID once the full message is assembled.
     func processPacket(_ data: Data, peripheralId: String) -> (data: Data, queryID: UInt8)? {
         guard !data.isEmpty else {
             ErrorHandler.bleError("Received empty data")
             return nil
         }
 
-        // Parse packet header according to GoPro BLE protocol
-        let packetHeader = data[0]
-        let packetType = (packetHeader >> 6) & 0x03 // Extract bits 7-6 for packet type
+        let header = data[0]
+        let isContinuation = (header & 0x80) != 0
 
-        ErrorHandler.debug("Received packet type \(packetType)", context: [
-            "peripheral_id": peripheralId,
-            "data": data.map { String(format: "%02x", $0) }.joined(separator: " ")
-        ])
-
-        // Handle continuation packets with message reconstruction
-        let isContinuationBit = (packetHeader & 0x20) != 0
-
-        // Check if this looks like an initial packet
-        let looksLikeInitialPacket = data.count >= 4 &&
-                                   data[3] == 0 &&
-                                   packetType != 2 &&
-                                   isContinuationBit
-
-        // Process as continuation packet if:
-        // 1. It's a type 2 packet, OR
-        // 2. It has continuation bit set AND doesn't look like an initial packet
-        if packetType == 2 || (isContinuationBit && !looksLikeInitialPacket) {
-            ErrorHandler.debug("Processing continuation packet", context: ["peripheral_id": peripheralId])
+        if isContinuation {
             return handleContinuationPacket(data: data, peripheralId: peripheralId)
+        } else {
+            return handleStartPacket(data: data, peripheralId: peripheralId)
         }
-
-        // Handle initial packets
-        return handleInitialPacket(data: data, peripheralId: peripheralId)
     }
 
-    /// Clear all buffers (useful for testing and error recovery)
     func clearBuffers() {
         continuationBuffer.removeAll()
         expectedMessageLength.removeAll()
         lastPacketTime.removeAll()
     }
 
-    /// Clear buffers for a specific peripheral
     func clearBuffers(for peripheralId: String) {
         let keysToRemove = continuationBuffer.keys.filter { $0.hasPrefix(peripheralId) }
         for key in keysToRemove {
@@ -70,14 +51,10 @@ class BLEPacketReconstructor {
         }
     }
 
-    /// Get current buffer state (useful for testing)
     func getBufferState() -> (buffers: [String: Data], expectedLengths: [String: Int]) {
         return (continuationBuffer, expectedMessageLength)
     }
 
-    /// Check for timeouts and force completion of incomplete responses
-    /// - Parameter timeoutInterval: Timeout interval in seconds (default: 5 seconds)
-    /// - Returns: Array of complete message data from timed out buffers
     func checkTimeouts(timeoutInterval: TimeInterval = 5.0) -> [(data: Data, queryID: UInt8)] {
         let now = Date()
         var results: [(data: Data, queryID: UInt8)] = []
@@ -97,7 +74,6 @@ class BLEPacketReconstructor {
             }
         }
 
-        // Clean up timed out buffers
         for key in keysToRemove {
             continuationBuffer.removeValue(forKey: key)
             expectedMessageLength.removeValue(forKey: key)
@@ -109,91 +85,96 @@ class BLEPacketReconstructor {
 
     // MARK: - Private Methods
 
-    /// Handle initial packets (single or first packet of multi-packet message)
-    private func handleInitialPacket(data: Data, peripheralId: String) -> (data: Data, queryID: UInt8)? {
-        guard data.count >= 4 else {
-            ErrorHandler.bleError("Initial packet too short", context: ["data_length": String(data.count)])
+    /// Parse a start packet header and extract the message length and payload offset.
+    /// Returns (messageLength, payloadStartIndex) or nil on error.
+    private func parseStartHeader(_ data: Data) -> (messageLength: Int, payloadStart: Int)? {
+        let header = data[0]
+        let headerType = (header >> 5) & 0x03
+
+        switch headerType {
+        case 0b00:
+            // General (5-bit): message length in bits 4-0
+            let messageLength = Int(header & 0x1F)
+            return (messageLength, 1)
+
+        case 0b01:
+            // Extended 13-bit: bits 4-0 of header + next byte
+            guard data.count >= 2 else {
+                ErrorHandler.bleError("Extended 13-bit packet too short", context: ["data_length": String(data.count)])
+                return nil
+            }
+            let messageLength = (Int(header & 0x1F) << 8) | Int(data[1])
+            return (messageLength, 2)
+
+        case 0b10:
+            // Extended 16-bit: next 2 bytes (receive-only format for messages >= 8192 bytes)
+            guard data.count >= 3 else {
+                ErrorHandler.bleError("Extended 16-bit packet too short", context: ["data_length": String(data.count)])
+                return nil
+            }
+            let messageLength = (Int(data[1]) << 8) | Int(data[2])
+            return (messageLength, 3)
+
+        default:
+            ErrorHandler.bleError("Reserved header type", context: ["header": String(format: "0x%02X", header)])
             return nil
-        }
-
-        let totalLength: Int
-        let queryID: Int
-        let _: Int // statusByte (unused for now)
-        let tlvStartIndex: Int
-
-        if data[3] == 0 {
-            // Format 1: [packetHeader] [totalLength] [queryID] [status=0] [TLV data...]
-            let packetTotalLength = Int(data[1])
-            queryID = Int(data[2])
-            _ = Int(data[3]) // statusByte
-            tlvStartIndex = 4
-            // For multipart responses, totalLength is the TLV data length (packet total - header bytes)
-            totalLength = packetTotalLength - 2  // Subtract [queryID][status] from total
-        } else {
-            // Format 2: [packetHeader] [queryID] [status] [TLV data...]
-            // This is a single-packet response, so totalLength = packet length - header
-            totalLength = data.count - 3  // Total data minus [header][queryID][status]
-            queryID = Int(data[1])
-            _ = Int(data[2]) // statusByte
-            tlvStartIndex = 3
-        }
-
-        let tlvData = data.subdata(in: tlvStartIndex..<data.count)
-
-        // Always use the buffer-based approach for consistency
-        let bufferKey = "\(peripheralId):\(queryID)"
-        continuationBuffer[bufferKey] = tlvData
-        expectedMessageLength[bufferKey] = totalLength
-        lastPacketTime[bufferKey] = Date()
-
-        ErrorHandler.debug("Initialized buffer for queryID", context: [
-            "query_id": String(queryID),
-            "tlv_data_length": String(tlvData.count),
-            "expected_total": String(totalLength)
-        ])
-
-        // Check if we already have the complete message (single packet case)
-        if tlvData.count >= totalLength {
-            ErrorHandler.debug("Complete message received in single packet", context: ["query_id": String(queryID)])
-
-            // Clear the buffer
-            continuationBuffer.removeValue(forKey: bufferKey)
-            expectedMessageLength.removeValue(forKey: bufferKey)
-            lastPacketTime.removeValue(forKey: bufferKey)
-
-            return (data: tlvData, queryID: UInt8(queryID))
-        } else {
-            ErrorHandler.debug("Incomplete message, waiting for continuation packets", context: ["query_id": String(queryID)])
-            return nil // Wait for continuation packets
         }
     }
 
-    /// Handle continuation packets by appending data to existing buffers
+    /// Handle a start packet (first or only packet of a message).
+    /// Message payload format for queries: [QueryID] [Status] [TLV data...]
+    private func handleStartPacket(data: Data, peripheralId: String) -> (data: Data, queryID: UInt8)? {
+        guard let (messageLength, payloadStart) = parseStartHeader(data) else {
+            return nil
+        }
+
+        let payloadInThisPacket = data.subdata(in: payloadStart..<data.count)
+
+        guard payloadInThisPacket.count >= 2 else {
+            ErrorHandler.bleError("Start packet payload too short for query response", context: [
+                "payload_length": String(payloadInThisPacket.count)
+            ])
+            return nil
+        }
+
+        let queryID = payloadInThisPacket[0]
+        // payloadInThisPacket[1] is the status byte (0 = success)
+        let tlvData = payloadInThisPacket.count > 2 ? payloadInThisPacket.subdata(in: 2..<payloadInThisPacket.count) : Data()
+        let expectedTLVLength = messageLength - 2
+
+        let bufferKey = "\(peripheralId):\(queryID)"
+        continuationBuffer[bufferKey] = tlvData
+        expectedMessageLength[bufferKey] = expectedTLVLength
+        lastPacketTime[bufferKey] = Date()
+
+        if tlvData.count >= expectedTLVLength {
+            continuationBuffer.removeValue(forKey: bufferKey)
+            expectedMessageLength.removeValue(forKey: bufferKey)
+            lastPacketTime.removeValue(forKey: bufferKey)
+            return (data: tlvData, queryID: queryID)
+        }
+
+        return nil
+    }
+
+    /// Handle a continuation packet by appending its payload to an existing buffer.
+    /// Continuation header: bit 7 = 1, bits 3-0 = sequence counter.
+    /// Payload starts at byte 1.
     private func handleContinuationPacket(data: Data, peripheralId: String) -> (data: Data, queryID: UInt8)? {
-        guard data.count >= 3 else {
+        guard data.count >= 2 else {
             ErrorHandler.bleError("Continuation packet too short", context: ["data_length": String(data.count)])
             return nil
         }
 
-        let sequenceCounter = data[0] & 0x0F // Lower 4 bits are sequence counter
-        let status = data[2] // Third byte is status
-
-        ErrorHandler.debug("Continuation packet received", context: [
-            "sequence": String(sequenceCounter),
-            "status": String(status),
-            "peripheral_id": peripheralId
-        ])
+        let payload = data.subdata(in: 1..<data.count)
 
         let bufferKeys = continuationBuffer.keys.filter { $0.hasPrefix(peripheralId) }
 
         if bufferKeys.isEmpty {
-            return handleFirstPacketOfMultipart(data: data, peripheralId: peripheralId)
+            ErrorHandler.bleError("No buffer found for continuation packet", context: ["peripheral_id": peripheralId])
+            return nil
         }
 
-        // When multiple buffers exist, pick the most recently active one.
-        // Continuation packets don't carry a query ID, so we use recency
-        // as the best heuristic. The GoPro BLE protocol expects one
-        // multipart response per characteristic at a time.
         let bufferKey: String
         if bufferKeys.count == 1 {
             bufferKey = bufferKeys[0]
@@ -210,41 +191,14 @@ class BLEPacketReconstructor {
             return nil
         }
 
-        // Extract TLV data from continuation packet
-        let packetType = (data[0] >> 6) & 0x03 // Extract bits 7-6 for packet type
-        let tlvData: Data
-        if packetType == 2 { // Type 2 packet
-            tlvData = data.subdata(in: 1..<data.count)
-        } else { // Type 1 packet with continuation bit
-            tlvData = data.subdata(in: 1..<data.count)
-        }
-
-        ErrorHandler.debug("Extracted TLV data from continuation packet", context: [
-            "tlv_data_length": String(tlvData.count),
-            "packet_type": String(packetType)
-        ])
-
-        // Append to buffer
-        buffer.append(tlvData)
+        buffer.append(payload)
         continuationBuffer[bufferKey] = buffer
         lastPacketTime[bufferKey] = Date()
 
-        ErrorHandler.debug("Buffer updated", context: [
-            "buffer_length": String(buffer.count),
-            "expected_length": String(expectedLength)
-        ])
-
-        // Check if we have the complete message
         if buffer.count >= expectedLength {
-            ErrorHandler.debug("Complete message received from continuation packets", context: [
-                "buffer_length": String(buffer.count)
-            ])
+            let parts = bufferKey.split(separator: ":")
+            let queryID = parts.count >= 2 ? (UInt8(parts[1]) ?? 0) : 0
 
-            // Extract query ID from buffer key
-            let queryIDString = bufferKey.split(separator: ":")[1]
-            let queryID = UInt8(queryIDString) ?? 0
-
-            // Clear the buffer
             continuationBuffer.removeValue(forKey: bufferKey)
             expectedMessageLength.removeValue(forKey: bufferKey)
             lastPacketTime.removeValue(forKey: bufferKey)
@@ -252,55 +206,6 @@ class BLEPacketReconstructor {
             return (data: buffer, queryID: queryID)
         }
 
-        return nil // Still waiting for more packets
-    }
-
-    /// Handle the first packet of a multipart response
-    private func handleFirstPacketOfMultipart(data: Data, peripheralId: String) -> (data: Data, queryID: UInt8)? {
-        let packetType = (data[0] >> 6) & 0x03
-        let isContinuationBit = (data[0] & 0x20) != 0
-        let looksLikeInitialPacket = data.count >= 4 &&
-                                   data[3] == 0 &&
-                                   packetType != 2 &&
-                                   isContinuationBit
-
-        if looksLikeInitialPacket {
-            ErrorHandler.debug("First packet of multipart response detected", context: ["peripheral_id": peripheralId])
-
-            let packetTotalLength = Int(data[1])
-            let queryID = Int(data[2])
-            let tlvData = data.subdata(in: 4..<data.count)
-
-            let bufferKey = "\(peripheralId):\(queryID)"
-            continuationBuffer[bufferKey] = tlvData
-            // For multipart responses, expectedMessageLength is the TLV data length (packet total - header bytes)
-            expectedMessageLength[bufferKey] = packetTotalLength - 2  // Subtract [queryID][status] from total
-            lastPacketTime[bufferKey] = Date()
-
-            let expectedTLVLength = packetTotalLength - 2  // Subtract [queryID][status] from total
-            ErrorHandler.debug("Initialized buffer for multipart response", context: [
-                "query_id": String(queryID),
-                "tlv_data_length": String(tlvData.count),
-                "expected_total": String(expectedTLVLength)
-            ])
-
-            // Check if we already have the complete message
-            if tlvData.count >= expectedTLVLength {
-                ErrorHandler.debug("Complete message received in single packet for multipart response", context: ["query_id": String(queryID)])
-
-                // Clear the buffer
-                continuationBuffer.removeValue(forKey: bufferKey)
-                expectedMessageLength.removeValue(forKey: bufferKey)
-                lastPacketTime.removeValue(forKey: bufferKey)
-
-                return (data: tlvData, queryID: UInt8(queryID))
-            } else {
-                ErrorHandler.debug("Incomplete multipart message, waiting for continuation packets", context: ["query_id": String(queryID)])
-                return nil // Wait for continuation packets
-            }
-        } else {
-            ErrorHandler.bleError("No buffer found for peripheral", context: ["peripheral_id": peripheralId])
-            return nil
-        }
+        return nil
     }
 }

--- a/Facett/GoProCommands.swift
+++ b/Facett/GoProCommands.swift
@@ -1,98 +1,93 @@
 import Foundation
 
 // MARK: - GoPro Command Definitions
-// Centralized command definitions to eliminate hardcoded arrays throughout the codebase
+// Centralized command definitions for the GoPro BLE protocol.
+// Byte arrays include the General (5-bit) packet header as the first byte.
+// See: https://gopro.github.io/OpenGoPro/ble/protocol/data_protocol.html
 
 struct GoProCommands {
 
     // MARK: - Status Query Commands
+    // Query ID 0x13 = Get Status Values
+    // Format: [header (length)] [0x13] [statusID1] [statusID2] ...
     struct Status {
-        // Consolidated status query - includes all status fields we need (20 byte limit)
-        static let status1: [UInt8] = [19, 19, 1, 2, 3, 6, 8, 10, 13, 31, 68, 70, 82, 85, 111, 114, 115, 116, 54, 113] // Added back type 3 (external battery present)
-        static let status2: [UInt8] = [4, 19, 78, 63, 109, 104]
+        static let status1: [UInt8] = [19, 0x13, 1, 2, 3, 6, 8, 10, 13, 31, 68, 70, 82, 85, 111, 114, 115, 116, 54, 113]
+        static let status2: [UInt8] = [4, 0x13, 78, 63, 109, 104]
 
-        // WiFi credentials query (separate query to avoid exceeding 20-byte limit)
-        static let wifiCredentials: [UInt8] = [19, 19, 29, 30, 69, 71, 72] // WiFi SSID, AP SSID, AP State, WiFi Password, AP Password
+        static let wifiCredentials: [UInt8] = [19, 0x13, 29, 30, 69, 71, 72]
+        static let wifiCredentialsAlt: [UInt8] = [19, 0x13, 29, 30, 69, 73, 74, 75]
 
-        // Alternative WiFi credentials query with different TLV types
-        static let wifiCredentialsAlt: [UInt8] = [19, 19, 29, 30, 69, 73, 74, 75] // Try different TLV types for passwords
-
-        // GPCAMERA_GET_WIFI_CONFIG command
-        static let getWiFiConfig: [UInt8] = [4, 241, 108, 8, 0] // Command to get WiFi configuration
+        // Protobuf: Feature 0xF1, Action 0x6C (undocumented)
+        static let getWiFiConfig: [UInt8] = [4, 0xF1, 0x6C, 0x08, 0x00]
     }
 
     // MARK: - Settings Query Commands
+    // Query ID 0x12 = Get Setting Values
+    // Format: [header (length)] [0x12] [settingID1] [settingID2] ...
     struct Settings {
-        // Consolidated settings query - includes all settings we need (20 byte limit each)
-        static let settings1: [UInt8] = [19, 18, 96, 102, 54, 85, 2, 3, 59, 83, 121, 134, 135, 162, 173, 149, 118, 124, 139, 144]
-        static let settings2: [UInt8] = [15, 18, 145, 13, 91, 115, 116, 167, 84, 86, 87, 88, 114, 79, 96]
-        static let settings3: [UInt8] = [18, 18, 48, 103, 104, 105, 106, 112, 154, 158, 159, 161, 60, 61, 62, 64, 65, 66, 67]
+        static let settings1: [UInt8] = [19, 0x12, 96, 102, 54, 85, 2, 3, 59, 83, 121, 134, 135, 162, 173, 149, 118, 124, 139, 144]
+        static let settings2: [UInt8] = [15, 0x12, 145, 13, 91, 115, 116, 167, 84, 86, 87, 88, 114, 79, 96]
+        static let settings3: [UInt8] = [18, 0x12, 48, 103, 104, 105, 106, 112, 154, 158, 159, 161, 60, 61, 62, 64, 65, 66, 67]
     }
 
     // MARK: - Control Commands
     struct Control {
-        // Claim control
-        static let claimControl: [UInt8] = [3, 23, 1, 1]
+        // Protobuf: Feature 0xF1, Action 0x69 (RequestSetCameraControlStatus)
+        // Value 2 = EXTERNAL (app claims control)
+        static let claimControl: [UInt8] = [0x04, 0xF1, 0x69, 0x08, 0x02]
 
-        // Release control
-        static let releaseControl: [UInt8] = [3, 23, 1, 0]
+        // Protobuf: Feature 0xF1, Action 0x69 (RequestSetCameraControlStatus)
+        // Value 0 = IDLE (app releases control)
+        static let releaseControl: [UInt8] = [0x04, 0xF1, 0x69, 0x08, 0x00]
 
-        // Sleep command
-        static let sleep: [UInt8] = [3, 23, 1, 2]
+        // TLV Command ID 0x05 = Sleep
+        static let sleep: [UInt8] = [0x01, 0x05]
 
-        // Power down command
-        static let powerDown: [UInt8] = [3, 23, 1, 3]
+        // TLV Command ID 0x11 = Reboot
+        static let reboot: [UInt8] = [0x01, 0x11]
     }
 
     // MARK: - AP (Access Point) Commands
+    // TLV Command ID 0x17 = Set AP Control
     struct AccessPoint {
-        // Enable AP
-        static let enable: [UInt8] = [3, 23, 1, 1]
+        // Parameter: 1 = enable
+        static let enable: [UInt8] = [0x03, 0x17, 0x01, 0x01]
 
-        // Disable AP
-        static let disable: [UInt8] = [3, 23, 1, 0]
+        // Parameter: 0 = disable
+        static let disable: [UInt8] = [0x03, 0x17, 0x01, 0x00]
     }
 
     // MARK: - Turbo Transfer Commands
+    // Protobuf: Feature 0xF1, Action 0x6B (RequestSetTurboActive)
     struct TurboTransfer {
-        // Enable turbo transfer
-        static let enable: [UInt8] = [4, 241, 107, 8, 1]
-
-        // Disable turbo transfer
-        static let disable: [UInt8] = [4, 241, 107, 8, 0]
+        static let enable: [UInt8] = [0x04, 0xF1, 0x6B, 0x08, 0x01]
+        static let disable: [UInt8] = [0x04, 0xF1, 0x6B, 0x08, 0x00]
     }
 
     // MARK: - Recording Commands
+    // TLV Command ID 0x01 = Set Shutter
     struct Recording {
-        // Start recording
-        static let start: [UInt8] = [3, 23, 1, 1]
+        // Parameter: 1 = shutter on (start recording)
+        static let start: [UInt8] = [0x03, 0x01, 0x01, 0x01]
 
-        // Stop recording
-        static let stop: [UInt8] = [3, 23, 1, 0]
+        // Parameter: 0 = shutter off (stop recording)
+        static let stop: [UInt8] = [0x03, 0x01, 0x01, 0x00]
     }
 
     // MARK: - Mode Commands
+    // Set Setting: Setting ID 144 (0x90) = camera mode (undocumented)
+    // CameraMode raw values: video=12, photo=17, multishot=19
     struct Mode {
-        // Set video mode
-        static let video: [UInt8] = [3, 23, 1, 12]
-
-        // Set photo mode
-        static let photo: [UInt8] = [3, 23, 1, 17]
-
-        // Set multishot mode
-        static let multishot: [UInt8] = [3, 23, 1, 19]
+        static let video: [UInt8] = [0x03, 0x90, 0x01, 0x0C]
+        static let photo: [UInt8] = [0x03, 0x90, 0x01, 0x11]
+        static let multishot: [UInt8] = [0x03, 0x90, 0x01, 0x13]
     }
-}
 
-// MARK: - Command Categories
-enum CommandCategory {
-    case status
-    case settings
-    case control
-    case accessPoint
-    case turboTransfer
-    case recording
-    case mode
+    // MARK: - Keep Alive
+    // TLV Command ID 0x5B, sent on the Setting characteristic
+    struct KeepAlive {
+        static let ping: [UInt8] = [0x02, 0x5B, 0x42]
+    }
 }
 
 // MARK: - Command Priority
@@ -104,91 +99,5 @@ enum CommandPriority: Int, Comparable {
 
     static func < (lhs: CommandPriority, rhs: CommandPriority) -> Bool {
         return lhs.rawValue < rhs.rawValue
-    }
-}
-
-// MARK: - Command Metadata
-struct CommandMetadata {
-    let command: [UInt8]
-    let name: String
-    let category: CommandCategory
-    let priority: CommandPriority
-    let timeout: TimeInterval
-    let requiresControl: Bool
-
-    init(command: [UInt8], name: String, category: CommandCategory, priority: CommandPriority = .normal, timeout: TimeInterval = 5.0, requiresControl: Bool = false) {
-        self.command = command
-        self.name = name
-        self.category = category
-        self.priority = priority
-        self.timeout = timeout
-        self.requiresControl = requiresControl
-    }
-}
-
-// MARK: - Command Registry
-class GoProCommandRegistry {
-    static let shared = GoProCommandRegistry()
-
-    private var commands: [String: CommandMetadata] = [:]
-
-    private init() {
-        registerDefaultCommands()
-    }
-
-    private func registerDefaultCommands() {
-        // Status commands
-        register(GoProCommands.Status.status1, name: "consolidated status1", category: .status, priority: .high)
-        register(GoProCommands.Status.status2, name: "consolidated status2", category: .status, priority: .high)
-        register(GoProCommands.Status.wifiCredentials, name: "WiFi credentials", category: .status, priority: .normal)
-        register(GoProCommands.Status.wifiCredentialsAlt, name: "WiFi credentials alt", category: .status, priority: .normal)
-        register(GoProCommands.Status.getWiFiConfig, name: "get WiFi config", category: .status, priority: .normal)
-
-        // Settings commands
-        register(GoProCommands.Settings.settings1, name: "consolidated settings1", category: .settings, priority: .normal)
-        register(GoProCommands.Settings.settings2, name: "consolidated settings2", category: .settings, priority: .normal)
-        register(GoProCommands.Settings.settings3, name: "consolidated settings3", category: .settings, priority: .normal)
-
-        // Control commands
-        register(GoProCommands.Control.claimControl, name: "claim control", category: .control, priority: .critical, requiresControl: true)
-        register(GoProCommands.Control.releaseControl, name: "release control", category: .control, priority: .critical, requiresControl: true)
-        register(GoProCommands.Control.sleep, name: "sleep", category: .control, priority: .high, requiresControl: true)
-        register(GoProCommands.Control.powerDown, name: "power down", category: .control, priority: .high, requiresControl: true)
-
-        // AP commands
-        register(GoProCommands.AccessPoint.enable, name: "enable AP", category: .accessPoint, priority: .normal)
-        register(GoProCommands.AccessPoint.disable, name: "disable AP", category: .accessPoint, priority: .normal)
-
-        // Turbo transfer commands
-        register(GoProCommands.TurboTransfer.enable, name: "enable turbo transfer", category: .turboTransfer, priority: .normal)
-        register(GoProCommands.TurboTransfer.disable, name: "disable turbo transfer", category: .turboTransfer, priority: .normal)
-
-        // Recording commands
-        register(GoProCommands.Recording.start, name: "start recording", category: .recording, priority: .high, requiresControl: true)
-        register(GoProCommands.Recording.stop, name: "stop recording", category: .recording, priority: .high, requiresControl: true)
-
-        // Mode commands
-        register(GoProCommands.Mode.video, name: "set video mode", category: .mode, priority: .normal)
-        register(GoProCommands.Mode.photo, name: "set photo mode", category: .mode, priority: .normal)
-        register(GoProCommands.Mode.multishot, name: "set multishot mode", category: .mode, priority: .normal)
-    }
-
-    private func register(_ command: [UInt8], name: String, category: CommandCategory, priority: CommandPriority = .normal, timeout: TimeInterval = 5.0, requiresControl: Bool = false) {
-        let key = command.map { String(format: "%02X", $0) }.joined()
-        let metadata = CommandMetadata(command: command, name: name, category: category, priority: priority, timeout: timeout, requiresControl: requiresControl)
-        commands[key] = metadata
-    }
-
-    func getMetadata(for command: [UInt8]) -> CommandMetadata? {
-        let key = command.map { String(format: "%02X", $0) }.joined()
-        return commands[key]
-    }
-
-    func getCommands(by category: CommandCategory) -> [CommandMetadata] {
-        return commands.values.filter { $0.category == category }
-    }
-
-    func getCommands(by priority: CommandPriority) -> [CommandMetadata] {
-        return commands.values.filter { $0.priority == priority }
     }
 }

--- a/FacettTests/ManualTest.swift
+++ b/FacettTests/ManualTest.swift
@@ -4,7 +4,7 @@ import Foundation
 // https://gopro.github.io/OpenGoPro/tutorials/parse-ble-responses#parsing-multiple-packet-tlv-responses
 
 // Copy the GoProBLEParser class here for testing
-class GoProBLEParser {
+class ManualTestBLEParser {
 
     // MARK: - Packet Reconstruction
 
@@ -246,13 +246,13 @@ class GoProBLEParser {
 // XCTest test class for GoProBLEParser
 import XCTest
 
-class GoProBLEParserTests: XCTestCase {
+class ManualBLEParserTests: XCTestCase {
 
-    var parser: GoProBLEParser!
+    var parser: ManualTestBLEParser!
 
     override func setUp() {
         super.setUp()
-        parser = GoProBLEParser()
+        parser = ManualTestBLEParser()
     }
 
     override func tearDown() {
@@ -361,7 +361,7 @@ class GoProBLEParserTests: XCTestCase {
 
     func testBufferStateManagement() {
         // Test 9: Buffer state management and cleanup
-        let parser = GoProBLEParser()
+        let parser = ManualTestBLEParser()
 
         // Start a multipart response
         let firstPacketData = Data([0x20, 0x5B, 0x00, 0x04, 0x00, 0x00, 0x00, 0x3E, 0x0C, 0x48, 0x45, 0x52, 0x4F, 0x31, 0x32, 0x20, 0x42, 0x6C, 0x61])
@@ -380,7 +380,7 @@ class GoProBLEParserTests: XCTestCase {
 
     func testMultiplePeripherals() {
         // Test 10: Multiple peripherals with independent buffers
-        let parser = GoProBLEParser()
+        let parser = ManualTestBLEParser()
 
         // Start multipart response for peripheral A
         let firstPacketA = Data([0x20, 0x5B, 0x00, 0x04, 0x00, 0x00, 0x00, 0x3E, 0x0C, 0x48, 0x45, 0x52, 0x4F, 0x31, 0x32, 0x20, 0x42, 0x6C, 0x61])
@@ -403,7 +403,7 @@ class GoProBLEParserTests: XCTestCase {
 
     func testContinuationPacketSequence() {
         // Test 11: Proper continuation packet sequence handling
-        let parser = GoProBLEParser()
+        let parser = ManualTestBLEParser()
 
         // Start multipart response
         let firstPacketData = Data([0x20, 0x5B, 0x00, 0x04, 0x00, 0x00, 0x00, 0x3E, 0x0C, 0x48, 0x45, 0x52, 0x4F, 0x31, 0x32, 0x20, 0x42, 0x6C, 0x61])
@@ -426,7 +426,7 @@ class GoProBLEParserTests: XCTestCase {
     func testRealGoProData() {
         // Test 12: Real GoPro data from user logs - this is the most important test!
         // This uses the exact packet sequence from your actual GoPro device
-        let parser = GoProBLEParser()
+        let parser = ManualTestBLEParser()
         let peripheralId = "2842C0A5-45B9-25F4-574A-F265889ED53B"
 
         // First packet: 20 3f 13 00 01 01 01 02 01 04 06 01 00 08 01 00 0a 01 00 0d
@@ -477,7 +477,7 @@ class GoProBLEParserTests: XCTestCase {
 
     func testRealGoProDataExpectedBytes() {
         // Test 13: Verify we extract the expected number of bytes from real data
-        let parser = GoProBLEParser()
+        let parser = ManualTestBLEParser()
         let peripheralId = "2842C0A5-45B9-25F4-574A-F265889ED53B"
 
         // Process first packet (expect 63 bytes total)
@@ -545,7 +545,7 @@ class GoProBLEParserTests: XCTestCase {
 
     func testRealGoProDataWithFifthPacket() {
         // Test 15: Test the specific fifth packet issue from the latest real data
-        let parser = GoProBLEParser()
+        let parser = ManualTestBLEParser()
         let peripheralId = "2842C0A5-45B9-25F4-574A-F265889ED53B"
 
         // First packet: 20 3f 13 00 01 01 01 02 01 04 06 01 00 08 01 00 0a 01 00 0d
@@ -592,7 +592,7 @@ class GoProBLEParserTests: XCTestCase {
 
     func testTwoStreamsConcurrently() {
         // Test 16: Test handling of two concurrent streams (query ID 19 and 18)
-        let parser = GoProBLEParser()
+        let parser = ManualTestBLEParser()
         let peripheralId = "2842C0A5-45B9-25F4-574A-F265889ED53B"
 
         // Process the multipart response for query ID 19 (4 packets, but incomplete)
@@ -637,7 +637,7 @@ class GoProBLEParserTests: XCTestCase {
     func testSinglePacketFormat2() {
         // Test 17: Test the alternative single packet format [header][queryID][status][TLV]
         // This is the format used by query ID 18: 0b 12 00 36 01 00 55 01 00 66 01 08
-        let parser = GoProBLEParser()
+        let parser = ManualTestBLEParser()
         let peripheralId = "test-peripheral"
 
         let packet = Data([0x0b, 0x12, 0x00, 0x36, 0x01, 0x00, 0x55, 0x01, 0x00, 0x66, 0x01, 0x08])
@@ -655,7 +655,7 @@ class GoProBLEParserTests: XCTestCase {
 
     func testInvalidPacketTypes() {
         // Test 14: Invalid packet types and edge cases
-        let parser = GoProBLEParser()
+        let parser = ManualTestBLEParser()
 
         // Empty packet
         let emptyResponses = parser.processPacket(Data(), peripheralId: "test-peripheral")

--- a/FacettTests/ParserTests.swift
+++ b/FacettTests/ParserTests.swift
@@ -1,7 +1,565 @@
 import XCTest
 @testable import Facett
 
-final class ParserTests: XCTestCase {
+// MARK: - Packet Reconstructor Tests
+
+final class PacketReconstructorTests: XCTestCase {
+    var reconstructor: BLEPacketReconstructor!
+
+    override func setUp() {
+        super.setUp()
+        reconstructor = BLEPacketReconstructor()
+    }
+
+    override func tearDown() {
+        reconstructor = nil
+        super.tearDown()
+    }
+
+    // MARK: - Empty / Invalid Input
+
+    func testEmptyData() {
+        let result = reconstructor.processPacket(Data(), peripheralId: "p1")
+        XCTAssertNil(result)
+    }
+
+    // MARK: - General (5-bit) Single-Packet Responses
+
+    func testGeneralSinglePacketStatusResponse() {
+        // Simulated status query response (query ID 0x13):
+        // Message: [0x13] [0x00 (success)] [TLV: type=70, len=1, val=85 (battery 85%)]
+        // Message length = 5 bytes → header = 0b000_00101 = 0x05
+        let packet = Data([0x05, 0x13, 0x00, 70, 0x01, 0x55])
+        let result = reconstructor.processPacket(packet, peripheralId: "p1")
+
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.queryID, 0x13)
+        // TLV data should be [70, 0x01, 0x55]
+        XCTAssertEqual(result?.data, Data([70, 0x01, 0x55]))
+    }
+
+    func testGeneralSinglePacketSettingsResponse() {
+        // Settings query response (query ID 0x12):
+        // Message: [0x12] [0x00] [TLV: type=2, len=1, val=1 (4K resolution)]
+        // Message length = 5 → header = 0x05
+        let packet = Data([0x05, 0x12, 0x00, 2, 0x01, 0x01])
+        let result = reconstructor.processPacket(packet, peripheralId: "p1")
+
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.queryID, 0x12)
+        XCTAssertEqual(result?.data, Data([2, 0x01, 0x01]))
+    }
+
+    func testGeneralMultipleTLVEntries() {
+        // Status response with two TLV entries:
+        // [type=70, len=1, val=50] [type=2, len=1, val=3]
+        // Message: [0x13] [0x00] [70, 1, 50, 2, 1, 3] → length = 8
+        let packet = Data([0x08, 0x13, 0x00, 70, 0x01, 50, 2, 0x01, 3])
+        let result = reconstructor.processPacket(packet, peripheralId: "p1")
+
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.queryID, 0x13)
+        XCTAssertEqual(result?.data.count, 6)
+    }
+
+    // MARK: - Extended 13-bit Multi-Packet Responses
+
+    func testExtended13BitSinglePacket() {
+        // Extended 13-bit header: bits 7-5 = 001, bits 4-0 + byte1 = 13-bit length
+        // Message length = 5 → upper 5 bits = 0, lower 8 bits = 5
+        // Header byte 0 = 0b001_00000 = 0x20, byte 1 = 0x05
+        // Message: [0x13] [0x00] [70, 1, 85]
+        let packet = Data([0x20, 0x05, 0x13, 0x00, 70, 0x01, 0x55])
+        let result = reconstructor.processPacket(packet, peripheralId: "p1")
+
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.queryID, 0x13)
+        XCTAssertEqual(result?.data, Data([70, 0x01, 0x55]))
+    }
+
+    func testExtended13BitMultiPacket() {
+        // First packet: Extended 13-bit, message length = 25 (more than fits in one 20-byte BLE packet)
+        // Header: 0b001_00000 = 0x20, length_low = 25
+        // Message starts: [0x13] [0x00] [TLV data...]
+        // First packet carries header(2) + queryID(1) + status(1) + 16 bytes TLV = 20 bytes total
+        var firstPacket = Data([0x20, 25, 0x13, 0x00])
+        let tlvChunk1 = Data(repeating: 0xAA, count: 16) // 16 bytes of TLV in first packet
+        firstPacket.append(tlvChunk1)
+
+        let result1 = reconstructor.processPacket(firstPacket, peripheralId: "p1")
+        XCTAssertNil(result1, "First packet should not complete the message (16 of 23 TLV bytes)")
+
+        // Continuation packet: header 0x80 (bit7=1, counter=0), then 7 remaining TLV bytes
+        var contPacket = Data([0x80])
+        let tlvChunk2 = Data(repeating: 0xBB, count: 7)
+        contPacket.append(tlvChunk2)
+
+        let result2 = reconstructor.processPacket(contPacket, peripheralId: "p1")
+        XCTAssertNotNil(result2, "Second packet should complete the message")
+        XCTAssertEqual(result2?.queryID, 0x13)
+        XCTAssertEqual(result2?.data.count, 23) // 25 - 2 (queryID + status)
+    }
+
+    func testExtended13BitThreePackets() {
+        // Message length = 40 → needs 3 packets
+        // Packet 1 (Extended 13-bit): header(2) + queryID + status + 16 TLV bytes = 20 bytes
+        var pkt1 = Data([0x20, 40, 0x12, 0x00])
+        pkt1.append(Data(repeating: 0x01, count: 16))
+
+        // Packet 2 (continuation, counter=0): header(1) + 19 TLV bytes = 20 bytes
+        var pkt2 = Data([0x80])
+        pkt2.append(Data(repeating: 0x02, count: 19))
+
+        // Packet 3 (continuation, counter=1): header(1) + 3 remaining TLV bytes
+        var pkt3 = Data([0x81])
+        pkt3.append(Data(repeating: 0x03, count: 3))
+
+        XCTAssertNil(reconstructor.processPacket(pkt1, peripheralId: "p1"))
+        XCTAssertNil(reconstructor.processPacket(pkt2, peripheralId: "p1"))
+
+        let result = reconstructor.processPacket(pkt3, peripheralId: "p1")
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.queryID, 0x12)
+        XCTAssertEqual(result?.data.count, 38) // 40 - 2
+    }
+
+    // MARK: - Extended 16-bit (receive-only)
+
+    func testExtended16Bit() {
+        // Header: bits 7-5 = 010 → 0b010_00000 = 0x40, then 2-byte length
+        // Message length = 5
+        let packet = Data([0x40, 0x00, 0x05, 0x13, 0x00, 70, 0x01, 0x55])
+        let result = reconstructor.processPacket(packet, peripheralId: "p1")
+
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.queryID, 0x13)
+        XCTAssertEqual(result?.data, Data([70, 0x01, 0x55]))
+    }
+
+    // MARK: - Continuation Packet Edge Cases
+
+    func testContinuationWithNoBuffer() {
+        // Continuation packet with no prior start packet should be dropped
+        let contPacket = Data([0x80, 0x01, 0x02, 0x03])
+        let result = reconstructor.processPacket(contPacket, peripheralId: "p1")
+        XCTAssertNil(result)
+    }
+
+    func testContinuationCounterWraparound() {
+        // Start a multi-packet message, then send continuations with counters 0-15
+        var pkt1 = Data([0x20, 200, 0x13, 0x00]) // Extended 13-bit, length = 200
+        pkt1.append(Data(repeating: 0xAA, count: 16))
+
+        XCTAssertNil(reconstructor.processPacket(pkt1, peripheralId: "p1"))
+
+        // Send continuations until we reach 198 TLV bytes (200 - 2)
+        var accumulated = 16
+        var counter: UInt8 = 0
+        while accumulated < 198 {
+            let remaining = 198 - accumulated
+            let chunkSize = min(19, remaining)
+            var pkt = Data([0x80 | (counter & 0x0F)])
+            pkt.append(Data(repeating: UInt8(counter), count: chunkSize))
+            let result = reconstructor.processPacket(pkt, peripheralId: "p1")
+
+            accumulated += chunkSize
+            if accumulated >= 198 {
+                XCTAssertNotNil(result, "Final continuation should complete the message")
+                XCTAssertEqual(result?.data.count, 198)
+            } else {
+                XCTAssertNil(result)
+            }
+            counter = (counter + 1) & 0x0F
+        }
+    }
+
+    // MARK: - Multiple Peripherals
+
+    func testInterleavedPeripherals() {
+        // Start multi-packet messages for two different peripherals
+        var pkt1a = Data([0x20, 25, 0x13, 0x00])
+        pkt1a.append(Data(repeating: 0xAA, count: 16))
+
+        var pkt1b = Data([0x20, 25, 0x12, 0x00])
+        pkt1b.append(Data(repeating: 0xBB, count: 16))
+
+        XCTAssertNil(reconstructor.processPacket(pkt1a, peripheralId: "p1"))
+        XCTAssertNil(reconstructor.processPacket(pkt1b, peripheralId: "p2"))
+
+        // Continuation for p2
+        var cont2 = Data([0x80])
+        cont2.append(Data(repeating: 0xCC, count: 7))
+        let result2 = reconstructor.processPacket(cont2, peripheralId: "p2")
+        XCTAssertNotNil(result2)
+        XCTAssertEqual(result2?.queryID, 0x12)
+
+        // Continuation for p1
+        var cont1 = Data([0x80])
+        cont1.append(Data(repeating: 0xDD, count: 7))
+        let result1 = reconstructor.processPacket(cont1, peripheralId: "p1")
+        XCTAssertNotNil(result1)
+        XCTAssertEqual(result1?.queryID, 0x13)
+    }
+
+    // MARK: - Buffer Management
+
+    func testClearBuffers() {
+        var pkt = Data([0x20, 25, 0x13, 0x00])
+        pkt.append(Data(repeating: 0xAA, count: 16))
+        XCTAssertNil(reconstructor.processPacket(pkt, peripheralId: "p1"))
+
+        let state1 = reconstructor.getBufferState()
+        XCTAssertFalse(state1.buffers.isEmpty)
+
+        reconstructor.clearBuffers()
+        let state2 = reconstructor.getBufferState()
+        XCTAssertTrue(state2.buffers.isEmpty)
+    }
+
+    func testClearBuffersForPeripheral() {
+        var pkt1 = Data([0x20, 25, 0x13, 0x00])
+        pkt1.append(Data(repeating: 0xAA, count: 16))
+        var pkt2 = Data([0x20, 25, 0x12, 0x00])
+        pkt2.append(Data(repeating: 0xBB, count: 16))
+
+        XCTAssertNil(reconstructor.processPacket(pkt1, peripheralId: "p1"))
+        XCTAssertNil(reconstructor.processPacket(pkt2, peripheralId: "p2"))
+
+        reconstructor.clearBuffers(for: "p1")
+        let state = reconstructor.getBufferState()
+        XCTAssertTrue(state.buffers.keys.allSatisfy { !$0.hasPrefix("p1") })
+        XCTAssertFalse(state.buffers.isEmpty) // p2 still has a buffer
+    }
+
+    func testTimeout() {
+        var pkt = Data([0x20, 25, 0x13, 0x00])
+        pkt.append(Data(repeating: 0xAA, count: 16))
+        XCTAssertNil(reconstructor.processPacket(pkt, peripheralId: "p1"))
+
+        // With a 0-second timeout, the buffer should be returned immediately
+        let results = reconstructor.checkTimeouts(timeoutInterval: 0)
+        XCTAssertEqual(results.count, 1)
+        XCTAssertEqual(results[0].queryID, 0x13)
+
+        // Buffer should be cleared after timeout
+        let state = reconstructor.getBufferState()
+        XCTAssertTrue(state.buffers.isEmpty)
+    }
+}
+
+// MARK: - TLV Parser Tests
+
+final class TLVParserTests: XCTestCase {
+    var tlvParser: BLETLVParser!
+
+    override func setUp() {
+        super.setUp()
+        tlvParser = BLETLVParser()
+    }
+
+    override func tearDown() {
+        tlvParser = nil
+        super.tearDown()
+    }
+
+    func testSingleTLVEntry() {
+        // Type=70 (battery %), Length=1, Value=85
+        let data = Data([70, 0x01, 85])
+        let entries = tlvParser.parseTLVData(data)
+
+        XCTAssertEqual(entries.count, 1)
+        XCTAssertEqual(entries[0].type, 70)
+        XCTAssertEqual(entries[0].length, 1)
+        XCTAssertEqual(entries[0].value, 85)
+    }
+
+    func testMultipleTLVEntries() {
+        // [type=1, len=1, val=1] [type=2, len=1, val=3] [type=70, len=1, val=50]
+        let data = Data([1, 1, 1, 2, 1, 3, 70, 1, 50])
+        let entries = tlvParser.parseTLVData(data)
+
+        XCTAssertEqual(entries.count, 3)
+        XCTAssertEqual(entries[0].type, 1)
+        XCTAssertEqual(entries[0].value, 1)
+        XCTAssertEqual(entries[1].type, 2)
+        XCTAssertEqual(entries[1].value, 3)
+        XCTAssertEqual(entries[2].type, 70)
+        XCTAssertEqual(entries[2].value, 50)
+    }
+
+    func testMultiByteValue() {
+        // Type=54 (SD card remaining KB), Length=4, Value = 0x003D0900 = 4,000,000
+        let data = Data([54, 4, 0x00, 0x3D, 0x09, 0x00])
+        let entries = tlvParser.parseTLVData(data)
+
+        XCTAssertEqual(entries.count, 1)
+        XCTAssertEqual(entries[0].type, 54)
+        XCTAssertEqual(entries[0].length, 4)
+        XCTAssertEqual(entries[0].value, 4_000_000)
+    }
+
+    func testBigEndianTwoByteValue() {
+        // Type=13, Length=2, Value = 0x01F4 = 500 (video duration in seconds)
+        let data = Data([13, 2, 0x01, 0xF4])
+        let entries = tlvParser.parseTLVData(data)
+
+        XCTAssertEqual(entries.count, 1)
+        XCTAssertEqual(entries[0].value, 500)
+    }
+
+    func testZeroLengthValue() {
+        // Type=8, Length=0 → no value bytes
+        let data = Data([8, 0])
+        let entries = tlvParser.parseTLVData(data)
+
+        XCTAssertEqual(entries.count, 1)
+        XCTAssertEqual(entries[0].type, 8)
+        XCTAssertEqual(entries[0].length, 0)
+        XCTAssertEqual(entries[0].value, 0)
+    }
+
+    func testTruncatedEntry() {
+        // Type=70, Length=4, but only 2 value bytes available → should stop parsing
+        let data = Data([70, 4, 0x01, 0x02])
+        let entries = tlvParser.parseTLVData(data)
+        XCTAssertEqual(entries.count, 0)
+    }
+
+    func testEmptyData() {
+        let entries = tlvParser.parseTLVData(Data())
+        XCTAssertTrue(entries.isEmpty)
+    }
+
+    func testStringValue() {
+        // Simulate an AP SSID (type 30): "GP12345678"
+        let ssidBytes: [UInt8] = Array("GP12345678".utf8)
+        var data = Data([30, UInt8(ssidBytes.count)])
+        data.append(Data(ssidBytes))
+
+        let entries = tlvParser.parseTLVData(data)
+        XCTAssertEqual(entries.count, 1)
+        XCTAssertEqual(entries[0].stringValue, "GP12345678")
+    }
+}
+
+// MARK: - Response Mapper Tests
+
+final class ResponseMapperTests: XCTestCase {
+    var mapper: BLEResponseMapper!
+    var tlvParser: BLETLVParser!
+
+    override func setUp() {
+        super.setUp()
+        mapper = BLEResponseMapper()
+        tlvParser = BLETLVParser()
+    }
+
+    override func tearDown() {
+        mapper = nil
+        tlvParser = nil
+        super.tearDown()
+    }
+
+    // MARK: - Status Responses (Query ID 0x13 = 19)
+
+    func testBatteryPresentStatus() {
+        let entries = tlvParser.parseTLVData(Data([1, 1, 1]))
+        let responses = mapper.mapToResponseTypes(entries: entries, queryID: 19)
+        XCTAssertEqual(responses.count, 1)
+        if case .batteryPresent(let present) = responses[0] {
+            XCTAssertTrue(present)
+        } else {
+            XCTFail("Expected batteryPresent response")
+        }
+    }
+
+    func testBatteryLevelStatus() {
+        // Status ID 2 = battery level (bars), value 3
+        let entries = tlvParser.parseTLVData(Data([2, 1, 3]))
+        let responses = mapper.mapToResponseTypes(entries: entries, queryID: 19)
+        XCTAssertEqual(responses.count, 1)
+        if case .batteryLevel(let level) = responses[0] {
+            XCTAssertEqual(level, 3)
+        } else {
+            XCTFail("Expected batteryLevel response")
+        }
+    }
+
+    func testBatteryPercentageStatus() {
+        // Status ID 70 = battery percentage, value 85
+        let entries = tlvParser.parseTLVData(Data([70, 1, 85]))
+        let responses = mapper.mapToResponseTypes(entries: entries, queryID: 19)
+        XCTAssertEqual(responses.count, 1)
+        if case .batteryPercentage(let pct) = responses[0] {
+            XCTAssertEqual(pct, 85)
+        } else {
+            XCTFail("Expected batteryPercentage response")
+        }
+    }
+
+    func testOverheatingStatus() {
+        let entries = tlvParser.parseTLVData(Data([6, 1, 1]))
+        let responses = mapper.mapToResponseTypes(entries: entries, queryID: 19)
+        if case .overheating(let hot) = responses[0] {
+            XCTAssertTrue(hot)
+        } else {
+            XCTFail("Expected overheating response")
+        }
+    }
+
+    func testEncodingStatus() {
+        let entries = tlvParser.parseTLVData(Data([10, 1, 1]))
+        let responses = mapper.mapToResponseTypes(entries: entries, queryID: 19)
+        if case .encoding(let enc) = responses[0] {
+            XCTAssertTrue(enc)
+        } else {
+            XCTFail("Expected encoding response")
+        }
+    }
+
+    func testIsReadyStatus() {
+        // Status ID 82 = system ready
+        let entries = tlvParser.parseTLVData(Data([82, 1, 1]))
+        let responses = mapper.mapToResponseTypes(entries: entries, queryID: 19)
+        if case .isReady(let ready) = responses[0] {
+            XCTAssertTrue(ready)
+        } else {
+            XCTFail("Expected isReady response")
+        }
+    }
+
+    func testGPSLockStatus() {
+        // Status ID 68 = GPS lock
+        let entries = tlvParser.parseTLVData(Data([68, 1, 0]))
+        let responses = mapper.mapToResponseTypes(entries: entries, queryID: 19)
+        if case .gpsLock(let lock) = responses[0] {
+            XCTAssertFalse(lock)
+        } else {
+            XCTFail("Expected gpsLock response")
+        }
+    }
+
+    func testCameraControlIdStatus() {
+        // Status ID 114 = camera control ID
+        let entries = tlvParser.parseTLVData(Data([114, 1, 2]))
+        let responses = mapper.mapToResponseTypes(entries: entries, queryID: 19)
+        if case .cameraControlId(let id) = responses[0] {
+            XCTAssertEqual(id, 2)
+        } else {
+            XCTFail("Expected cameraControlId response")
+        }
+    }
+
+    func testSDCardRemainingStatus() {
+        // Status ID 54 = SD card remaining KB, 4 bytes → 4,000,000 KB
+        let entries = tlvParser.parseTLVData(Data([54, 4, 0x00, 0x3D, 0x09, 0x00]))
+        let responses = mapper.mapToResponseTypes(entries: entries, queryID: 19)
+        if case .sdCardRemaining(let kb) = responses[0] {
+            XCTAssertEqual(kb, 4_000_000)
+        } else {
+            XCTFail("Expected sdCardRemaining response")
+        }
+    }
+
+    func testMultipleStatusResponses() {
+        // Two TLV entries: battery present (1) + battery percentage (85%)
+        let data = Data([1, 1, 1, 70, 1, 85])
+        let entries = tlvParser.parseTLVData(data)
+        let responses = mapper.mapToResponseTypes(entries: entries, queryID: 19)
+        XCTAssertEqual(responses.count, 2)
+    }
+
+    // MARK: - Settings Responses (Query ID 0x12 = 18)
+
+    func testVideoResolutionSetting() {
+        // Setting ID 2 = video resolution, value 1 (4K)
+        let entries = tlvParser.parseTLVData(Data([2, 1, 1]))
+        let responses = mapper.mapToResponseTypes(entries: entries, queryID: 18)
+        if case .videoResolution(let res) = responses[0] {
+            XCTAssertEqual(res, 1)
+        } else {
+            XCTFail("Expected videoResolution response")
+        }
+    }
+
+    func testFPSSetting() {
+        // Setting ID 3 = FPS, value 5 (60fps)
+        let entries = tlvParser.parseTLVData(Data([3, 1, 5]))
+        let responses = mapper.mapToResponseTypes(entries: entries, queryID: 18)
+        if case .framesPerSecond(let fps) = responses[0] {
+            XCTAssertEqual(fps, 5)
+        } else {
+            XCTFail("Expected framesPerSecond response")
+        }
+    }
+
+    func testGPSSetting() {
+        // Setting ID 83 = GPS, value 1 (enabled)
+        let entries = tlvParser.parseTLVData(Data([83, 1, 1]))
+        let responses = mapper.mapToResponseTypes(entries: entries, queryID: 18)
+        if case .gps(let enabled) = responses[0] {
+            XCTAssertTrue(enabled)
+        } else {
+            XCTFail("Expected gps response")
+        }
+    }
+
+    func testAntiFlickerSetting() {
+        // Setting ID 134 = anti-flicker
+        let entries = tlvParser.parseTLVData(Data([134, 1, 0]))
+        let responses = mapper.mapToResponseTypes(entries: entries, queryID: 18)
+        if case .antiFlicker(let val) = responses[0] {
+            XCTAssertEqual(val, 0)
+        } else {
+            XCTFail("Expected antiFlicker response")
+        }
+    }
+
+    func testModeSetting() {
+        // Setting ID 144 = mode (undocumented), value 12 (video)
+        let entries = tlvParser.parseTLVData(Data([144, 1, 12]))
+        let responses = mapper.mapToResponseTypes(entries: entries, queryID: 18)
+        if case .mode(let mode) = responses[0] {
+            XCTAssertEqual(mode, 12)
+        } else {
+            XCTFail("Expected mode response")
+        }
+    }
+
+    func testMaxLensSetting() {
+        // Setting ID 162 = max lens, value 1 (enabled)
+        let entries = tlvParser.parseTLVData(Data([162, 1, 1]))
+        let responses = mapper.mapToResponseTypes(entries: entries, queryID: 18)
+        if case .maxLens(let enabled) = responses[0] {
+            XCTAssertTrue(enabled)
+        } else {
+            XCTFail("Expected maxLens response")
+        }
+    }
+
+    func testUnknownQueryID() {
+        let entries = tlvParser.parseTLVData(Data([1, 1, 1]))
+        let responses = mapper.mapToResponseTypes(entries: entries, queryID: 99)
+        XCTAssertTrue(responses.isEmpty)
+    }
+
+    // MARK: - Query ID 20 (Settings variant)
+
+    func testQueryID20RoutesToSettings() {
+        // Query ID 20 should also be treated as settings
+        let entries = tlvParser.parseTLVData(Data([2, 1, 3]))
+        let responses = mapper.mapToResponseTypes(entries: entries, queryID: 20)
+        if case .videoResolution(let res) = responses[0] {
+            XCTAssertEqual(res, 3)
+        } else {
+            XCTFail("Expected videoResolution via query ID 20")
+        }
+    }
+}
+
+// MARK: - Full Pipeline Tests (GoProBLEParser)
+
+final class BLEParserPipelineTests: XCTestCase {
     var parser: GoProBLEParser!
 
     override func setUp() {
@@ -14,53 +572,223 @@ final class ParserTests: XCTestCase {
         super.tearDown()
     }
 
-    func testParserInitialization() {
-        XCTAssertNotNil(parser, "Parser should be initialized")
-    }
-
     func testEmptyData() {
-        let emptyData = Data()
-        let responses = parser.processPacket(emptyData, peripheralId: "test-peripheral")
-
-        XCTAssertTrue(responses.isEmpty, "Empty data should return no responses")
+        let responses = parser.processPacket(Data(), peripheralId: "p1")
+        XCTAssertTrue(responses.isEmpty)
     }
 
-    func testInvalidPacket() {
-        let invalidData = Data([0xFF, 0xFF, 0xFF]) // Invalid packet
-        let responses = parser.processPacket(invalidData, peripheralId: "test-peripheral")
+    func testSinglePacketBatteryStatus() {
+        // General header, status query response with battery percentage = 85%
+        // Header: length = 5 → 0x05
+        // Message: [0x13] [0x00] [70, 1, 85]
+        let packet = Data([0x05, 0x13, 0x00, 70, 0x01, 85])
+        let responses: [ResponseType] = parser.processPacket(packet, peripheralId: "p1")
 
-        XCTAssertTrue(responses.isEmpty, "Invalid packet should return no responses")
+        XCTAssertEqual(responses.count, 1)
+        if case .batteryPercentage(let pct) = responses[0] {
+            XCTAssertEqual(pct, 85)
+        } else {
+            XCTFail("Expected batteryPercentage")
+        }
     }
 
-    func testShortPacket() {
-        let shortData = Data([0x01, 0x02]) // Too short to be valid
-        let responses = parser.processPacket(shortData, peripheralId: "test-peripheral")
+    func testSinglePacketMultipleStatuses() {
+        // Status response with: battery present (1=yes), battery level (2=3 bars), overheating (6=no)
+        // TLV: [1,1,1] [2,1,3] [6,1,0] = 9 bytes
+        // Message: [0x13] [0x00] + 9 = 11 bytes
+        let packet = Data([11, 0x13, 0x00, 1, 1, 1, 2, 1, 3, 6, 1, 0])
+        let responses = parser.processPacket(packet, peripheralId: "p1")
 
-        XCTAssertTrue(responses.isEmpty, "Short packet should return no responses")
+        XCTAssertEqual(responses.count, 3)
     }
 
-    func testMultiplePeripherals() {
-        // Test that different peripherals can be processed independently
-        let data1 = Data([0x01, 0x02, 0x03, 0x04])
-        let data2 = Data([0x05, 0x06, 0x07, 0x08])
+    func testMultiPacketSettingsResponse() {
+        // Simulate a settings response that spans two packets
+        // Extended 13-bit header, message length = 23 (queryID + status + 21 TLV bytes)
+        // TLV: 7 entries of [settingID, 1, value] = 21 bytes
+        let settingsEntries: [(UInt8, UInt8)] = [
+            (2, 1),   // video resolution = 1 (4K)
+            (3, 5),   // FPS = 5 (60fps)
+            (83, 1),  // GPS = enabled
+            (134, 0), // anti-flicker = 50Hz
+            (135, 1), // hypersmooth = on
+            (162, 0), // max lens = off
+            (173, 0) // video perf mode = max
+        ]
 
-        let responses1 = parser.processPacket(data1, peripheralId: "peripheral-1")
-        let responses2 = parser.processPacket(data2, peripheralId: "peripheral-2")
+        var tlvData = Data()
+        for (id, val) in settingsEntries {
+            tlvData.append(contentsOf: [id, 0x01, val])
+        }
 
-        // Both should return empty responses since the data is invalid
-        XCTAssertTrue(responses1.isEmpty, "Invalid data for peripheral 1 should return no responses")
-        XCTAssertTrue(responses2.isEmpty, "Invalid data for peripheral 2 should return no responses")
+        let messageLength = 2 + tlvData.count // queryID + status + TLV
+
+        // First packet (Extended 13-bit): [header, length_low, queryID, status, TLV chunk 1]
+        var pkt1 = Data([0x20, UInt8(messageLength), 0x12, 0x00])
+        let chunk1Size = min(tlvData.count, 16) // 20 - 4 header bytes
+        pkt1.append(tlvData.subdata(in: 0..<chunk1Size))
+
+        let responses1 = parser.processPacket(pkt1, peripheralId: "p1")
+        XCTAssertTrue(responses1.isEmpty, "First packet should not produce responses yet")
+
+        // Continuation packet with remaining TLV data
+        var pkt2 = Data([0x80])
+        pkt2.append(tlvData.subdata(in: chunk1Size..<tlvData.count))
+
+        let responses2 = parser.processPacket(pkt2, peripheralId: "p1")
+        XCTAssertEqual(responses2.count, 7, "Should parse all 7 settings")
     }
 
     func testBufferCleanup() {
-        // Test that the parser can handle multiple calls without crashing
-        let data = Data([0x01, 0x02, 0x03, 0x04])
+        parser.clearBuffers()
+        let state = parser.getBufferState()
+        XCTAssertTrue(state.buffers.isEmpty)
+    }
+}
 
-        // Multiple calls should not crash
-        _ = parser.processPacket(data, peripheralId: "test-peripheral")
-        _ = parser.processPacket(data, peripheralId: "test-peripheral")
-        _ = parser.processPacket(data, peripheralId: "test-peripheral")
+// MARK: - Command Byte Verification Tests
 
-        XCTAssertTrue(true, "Multiple calls should not crash")
+final class GoProCommandTests: XCTestCase {
+
+    func testStatusQueryFormat() {
+        let cmd = GoProCommands.Status.status1
+        XCTAssertEqual(cmd[0], 19, "Header should indicate 19-byte message")
+        XCTAssertEqual(cmd[1], 0x13, "Query ID should be 0x13 (Get Status Values)")
+        XCTAssertEqual(cmd.count, 20, "Should fit in one BLE packet (20 bytes)")
+    }
+
+    func testSettingsQueryFormat() {
+        let cmd = GoProCommands.Settings.settings1
+        XCTAssertEqual(cmd[0], 19, "Header should indicate 19-byte message")
+        XCTAssertEqual(cmd[1], 0x12, "Query ID should be 0x12 (Get Setting Values)")
+        XCTAssertEqual(cmd.count, 20)
+    }
+
+    func testRecordingStartCommand() {
+        // Set Shutter: Command ID 0x01, param length 1, param value 1
+        let cmd = GoProCommands.Recording.start
+        XCTAssertEqual(cmd, [0x03, 0x01, 0x01, 0x01])
+        XCTAssertEqual(cmd[0] & 0x1F, 3, "Message length should be 3")
+        XCTAssertEqual(cmd[1], 0x01, "Command ID should be Set Shutter (0x01)")
+    }
+
+    func testRecordingStopCommand() {
+        let cmd = GoProCommands.Recording.stop
+        XCTAssertEqual(cmd, [0x03, 0x01, 0x01, 0x00])
+        XCTAssertEqual(cmd[3], 0x00, "Shutter parameter should be 0 (off)")
+    }
+
+    func testSleepCommand() {
+        // Sleep: Command ID 0x05, no parameters
+        let cmd = GoProCommands.Control.sleep
+        XCTAssertEqual(cmd, [0x01, 0x05])
+        XCTAssertEqual(cmd[0] & 0x1F, 1, "Message length should be 1")
+        XCTAssertEqual(cmd[1], 0x05, "Command ID should be Sleep (0x05)")
+    }
+
+    func testClaimControlCommand() {
+        // Protobuf: Feature 0xF1, Action 0x69, payload [0x08, 0x02]
+        let cmd = GoProCommands.Control.claimControl
+        XCTAssertEqual(cmd[0] & 0x1F, 4, "Message length should be 4")
+        XCTAssertEqual(cmd[1], 0xF1, "Feature ID should be 0xF1")
+        XCTAssertEqual(cmd[2], 0x69, "Action ID should be 0x69 (Set Camera Control)")
+        XCTAssertEqual(cmd[4], 0x02, "Control value should be 2 (EXTERNAL)")
+    }
+
+    func testReleaseControlCommand() {
+        let cmd = GoProCommands.Control.releaseControl
+        XCTAssertEqual(cmd[1], 0xF1)
+        XCTAssertEqual(cmd[2], 0x69)
+        XCTAssertEqual(cmd[4], 0x00, "Control value should be 0 (IDLE)")
+    }
+
+    func testAPEnableCommand() {
+        // Set AP Control: Command ID 0x17, param 1 = enable
+        let cmd = GoProCommands.AccessPoint.enable
+        XCTAssertEqual(cmd, [0x03, 0x17, 0x01, 0x01])
+    }
+
+    func testAPDisableCommand() {
+        let cmd = GoProCommands.AccessPoint.disable
+        XCTAssertEqual(cmd, [0x03, 0x17, 0x01, 0x00])
+    }
+
+    func testTurboTransferCommand() {
+        let cmd = GoProCommands.TurboTransfer.enable
+        XCTAssertEqual(cmd[1], 0xF1, "Feature ID should be 0xF1")
+        XCTAssertEqual(cmd[2], 0x6B, "Action ID should be 0x6B (Set Turbo Transfer)")
+    }
+
+    func testModeVideoCommand() {
+        // Set Setting 144 (0x90) to 12 (video)
+        let cmd = GoProCommands.Mode.video
+        XCTAssertEqual(cmd[1], 0x90, "Setting ID should be 0x90 (mode)")
+        XCTAssertEqual(cmd[3], 12, "Mode value should be 12 (video)")
+    }
+
+    func testModePhotoCommand() {
+        let cmd = GoProCommands.Mode.photo
+        XCTAssertEqual(cmd[1], 0x90)
+        XCTAssertEqual(cmd[3], 17, "Mode value should be 17 (photo)")
+    }
+
+    func testModeMultishotCommand() {
+        let cmd = GoProCommands.Mode.multishot
+        XCTAssertEqual(cmd[1], 0x90)
+        XCTAssertEqual(cmd[3], 19, "Mode value should be 19 (multishot)")
+    }
+
+    func testCommandsAreUnique() {
+        // Verify no two distinct commands share the same byte arrays
+        let commands: [(String, [UInt8])] = [
+            ("Control.claimControl", GoProCommands.Control.claimControl),
+            ("Control.releaseControl", GoProCommands.Control.releaseControl),
+            ("Control.sleep", GoProCommands.Control.sleep),
+            ("Control.reboot", GoProCommands.Control.reboot),
+            ("AccessPoint.enable", GoProCommands.AccessPoint.enable),
+            ("AccessPoint.disable", GoProCommands.AccessPoint.disable),
+            ("TurboTransfer.enable", GoProCommands.TurboTransfer.enable),
+            ("TurboTransfer.disable", GoProCommands.TurboTransfer.disable),
+            ("Recording.start", GoProCommands.Recording.start),
+            ("Recording.stop", GoProCommands.Recording.stop),
+            ("Mode.video", GoProCommands.Mode.video),
+            ("Mode.photo", GoProCommands.Mode.photo),
+            ("Mode.multishot", GoProCommands.Mode.multishot)
+        ]
+
+        for i in 0..<commands.count {
+            for j in (i + 1)..<commands.count {
+                let (name1, bytes1) = commands[i]
+                let (name2, bytes2) = commands[j]
+                XCTAssertNotEqual(bytes1, bytes2, "\(name1) and \(name2) must not share the same byte array")
+            }
+        }
+    }
+
+    func testHeaderLengthConsistency() {
+        // For each command, verify the header byte's 5-bit length matches actual payload
+        let commands: [String: [UInt8]] = [
+            "sleep": GoProCommands.Control.sleep,
+            "reboot": GoProCommands.Control.reboot,
+            "claimControl": GoProCommands.Control.claimControl,
+            "releaseControl": GoProCommands.Control.releaseControl,
+            "apEnable": GoProCommands.AccessPoint.enable,
+            "apDisable": GoProCommands.AccessPoint.disable,
+            "turboEnable": GoProCommands.TurboTransfer.enable,
+            "turboDisable": GoProCommands.TurboTransfer.disable,
+            "recStart": GoProCommands.Recording.start,
+            "recStop": GoProCommands.Recording.stop,
+            "modeVideo": GoProCommands.Mode.video,
+            "modePhoto": GoProCommands.Mode.photo,
+            "modeMultishot": GoProCommands.Mode.multishot,
+            "keepAlive": GoProCommands.KeepAlive.ping
+        ]
+
+        for (name, cmd) in commands {
+            let declaredLength = Int(cmd[0] & 0x1F)
+            let actualPayload = cmd.count - 1
+            XCTAssertEqual(declaredLength, actualPayload,
+                           "\(name): header says \(declaredLength) bytes but payload is \(actualPayload)")
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Fixes incorrect command byte arrays in `GoProCommands.swift` that would send wrong BLE commands (e.g., Recording start/stop was sending AP Control instead of Set Shutter)
- Rewrites `BLEPacketReconstructor` to properly parse packet headers per the GoPro Open API spec instead of using fragile heuristics
- Adds 60 new unit tests with simulated BLE packet data covering the full parser pipeline
- Fixes incorrect protocol documentation in `BLE_PROTOCOL.md`
- Removes dead code (`GoProCommandRegistry`, `CommandMetadata`, `CommandCategory`)

### Command fixes
| Command | Was (wrong) | Now (correct) |
|---------|------------|---------------|
| Recording.start | `[3, 0x17, 1, 1]` (AP Control enable) | `[3, 0x01, 1, 1]` (Set Shutter on) |
| Recording.stop | `[3, 0x17, 1, 0]` (AP Control disable) | `[3, 0x01, 1, 0]` (Set Shutter off) |
| Control.claimControl | `[3, 0x17, 1, 1]` (AP Control) | `[4, 0xF1, 0x69, 0x08, 0x02]` (Protobuf) |
| Control.releaseControl | `[3, 0x17, 1, 0]` (AP Control) | `[4, 0xF1, 0x69, 0x08, 0x00]` (Protobuf) |
| Control.sleep | `[3, 0x17, 1, 2]` (AP Control bounce) | `[1, 0x05]` (Sleep command) |
| Mode.video/photo/multishot | `[3, 0x17, 1, N]` (AP Control) | `[3, 0x90, 1, N]` (Set Setting 144) |

### Header parsing fix
The old code used `data[3] == 0` heuristic to distinguish packet formats. The new code properly checks bit 7 (start vs continuation) and bits 6-5 (General/Extended 13-bit/Extended 16-bit) per the spec.

## Test plan
- [x] 60 new tests pass locally (PacketReconstructor, TLVParser, ResponseMapper, full pipeline, command verification)
- [x] 22 existing tests still pass (Settings, StateMachine)
- [ ] CI build and lint passes

Fixes #41

Made with [Cursor](https://cursor.com)