### PR TITLE
Rename DispatchQueue labels to match bundle identifier

### DIFF
--- a/Facett/BLEManager.swift
+++ b/Facett/BLEManager.swift
@@ -617,7 +617,7 @@ class BLEManager: NSObject, ObservableObject, CBCentralManagerDelegate, CBPeriph
         recordingManager = BLERecordingManager(bleManager: self, modeManager: modeManager)
 
         // Use a background queue for BLE operations to avoid blocking UI
-        let bleQueue = DispatchQueue(label: "com.gopro.ble", qos: .utility)
+        let bleQueue = DispatchQueue(label: "com.kmatzen.facett.ble", qos: .utility)
         centralManager = CBCentralManager(delegate: self, queue: bleQueue)
 
         // Set up component callbacks
@@ -1991,7 +1991,7 @@ class BLEManager: NSObject, ObservableObject, CBCentralManagerDelegate, CBPeriph
 
     func startDeviceQueryTimer() {
         // CRITICAL FIX: Run timer on background queue to avoid blocking main thread during keyboard presentation
-        let bleQueue = DispatchQueue(label: "com.gopro.ble.timer", qos: .utility)
+        let bleQueue = DispatchQueue(label: "com.kmatzen.facett.ble.timer", qos: .utility)
         bleQueue.async {
             DispatchQueue.main.async {
                 self.deviceQueryTimer = Timer.scheduledTimer(withTimeInterval: 5.0, repeats: false) { [weak self] _ in
@@ -2025,7 +2025,7 @@ class BLEManager: NSObject, ObservableObject, CBCentralManagerDelegate, CBPeriph
 
     func startDeviceScanTimer() {
         // CRITICAL FIX: Run scan timer operations on background queue to avoid blocking main thread
-        let bleQueue = DispatchQueue(label: "com.gopro.ble.scan", qos: .utility)
+        let bleQueue = DispatchQueue(label: "com.kmatzen.facett.ble.scan", qos: .utility)
         DispatchQueue.main.async {
             self.deviceScanTimer = Timer.scheduledTimer(withTimeInterval: 3, repeats: false) { [weak self] _ in
                 guard let self = self else { return }

--- a/Facett/ConfigManager.swift
+++ b/Facett/ConfigManager.swift
@@ -8,7 +8,7 @@ class ConfigManager: ObservableObject {
     @Published var autoSyncEnabled: Bool = false
     @Published var isAutoSyncing: Bool = false
     private var syncInProgress: Bool = false // Internal sync state tracking
-    private let syncQueue = DispatchQueue(label: "com.gopro.sync", qos: .userInitiated)
+    private let syncQueue = DispatchQueue(label: "com.kmatzen.facett.sync", qos: .userInitiated)
 
     private let userDefaults = UserDefaults.standard
     private let configsKey = "CameraConfigs"


### PR DESCRIPTION
## Summary
- Renames 4 `DispatchQueue` labels from `com.gopro.*` to `com.kmatzen.facett.*` to match the app's bundle identifier
- One queue (`bleCommandQueue`) already had the correct prefix

## Test plan
- [x] Builds successfully
- [ ] CI passes

Fixes #43

Made with [Cursor](https://cursor.com)