### PR TITLE
Add code coverage reporting to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,4 +41,34 @@ jobs:
             -only-testing:FacettTests/GoProCommandTests \
             -only-testing:FacettTests/SettingsTests \
             -only-testing:FacettTests/StateMachineTests \
-            -quiet
+            -enableCodeCoverage YES \
+            -resultBundlePath TestResults.xcresult
+
+      - name: Code Coverage Summary
+        if: always()
+        run: |
+          if [ -d TestResults.xcresult ]; then
+            xcrun xccov view --report --json TestResults.xcresult > coverage.json
+            echo "## Code Coverage" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            python3 -c "
+          import json, sys
+          with open('coverage.json') as f:
+              data = json.load(f)
+          targets = data.get('targets', [])
+          for t in targets:
+              name = t.get('name', '')
+              if name == 'Facett.app':
+                  pct = t.get('lineCoverage', 0) * 100
+                  print(f'**{name}**: {pct:.1f}% line coverage')
+                  sys.stdout.flush()
+                  files = t.get('files', [])
+                  covered = [(f['name'], f['lineCoverage'] * 100) for f in files if f.get('lineCoverage', 0) > 0]
+                  covered.sort(key=lambda x: -x[1])
+                  print()
+                  print('| File | Coverage |')
+                  print('|------|----------|')
+                  for fname, cov in covered[:20]:
+                      print(f'| {fname} | {cov:.1f}% |')
+          " >> $GITHUB_STEP_SUMMARY
+          fi


### PR DESCRIPTION
## Summary
- Enables code coverage collection in the test step via `-enableCodeCoverage YES`
- Outputs results to a `.xcresult` bundle
- Adds a "Code Coverage Summary" step that extracts per-file line coverage using `xccov` and renders it as a table in the GitHub Actions step summary

## Test plan
- [ ] CI passes and coverage summary appears in the Actions run summary

Fixes #54

Made with [Cursor](https://cursor.com)