### PR TITLE
Add tests for CameraSettingDescriptions, ErrorHandler, CameraGroupManager

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,9 @@ jobs:
             -only-testing:FacettTests/GoProCommandTests \
             -only-testing:FacettTests/SettingsTests \
             -only-testing:FacettTests/StateMachineTests \
+            -only-testing:FacettTests/CameraSettingDescriptionTests \
+            -only-testing:FacettTests/ErrorHandlerTests \
+            -only-testing:FacettTests/CameraGroupTests \
             -enableCodeCoverage YES \
             -resultBundlePath TestResults.xcresult
 

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -5,7 +5,6 @@ line_length:
 file_length:
   warning: 1000
   error: 2600
-  ignores_comments: true
 
 type_body_length:
   warning: 800

--- a/FacettTests/CameraGroupTests.swift
+++ b/FacettTests/CameraGroupTests.swift
@@ -1,0 +1,172 @@
+import XCTest
+@testable import Facett
+
+final class CameraGroupTests: XCTestCase {
+
+    var configManager: ConfigManager!
+    var groupManager: CameraGroupManager!
+
+    override func setUp() {
+        super.setUp()
+        configManager = ConfigManager()
+        groupManager = CameraGroupManager(configManager: configManager)
+        groupManager.cameraGroups.removeAll()
+    }
+
+    override func tearDown() {
+        groupManager = nil
+        configManager = nil
+        super.tearDown()
+    }
+
+    // MARK: - CameraGroup Model
+
+    func testCameraGroupInit() {
+        let group = CameraGroup(name: "Test Group")
+        XCTAssertEqual(group.name, "Test Group")
+        XCTAssertTrue(group.cameraSerials.isEmpty)
+        XCTAssertFalse(group.isActive)
+        XCTAssertNil(group.configId)
+    }
+
+    func testCameraGroupInitWithSerials() {
+        let group = CameraGroup(name: "Group", cameraSerials: ["GP001", "GP002"])
+        XCTAssertEqual(group.cameraSerials.count, 2)
+        XCTAssertTrue(group.cameraSerials.contains("GP001"))
+    }
+
+    func testCameraGroupCodable() throws {
+        let original = CameraGroup(name: "Codable Test", cameraSerials: ["S1", "S2"])
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(CameraGroup.self, from: data)
+
+        XCTAssertEqual(decoded.id, original.id)
+        XCTAssertEqual(decoded.name, original.name)
+        XCTAssertEqual(decoded.cameraSerials, original.cameraSerials)
+    }
+
+    // MARK: - Add Group
+
+    func testAddCameraGroup() {
+        groupManager.addCameraGroup(name: "Alpha")
+
+        XCTAssertEqual(groupManager.cameraGroups.count, 1)
+        XCTAssertEqual(groupManager.cameraGroups.first?.name, "Alpha")
+    }
+
+    func testAddFirstGroupAutoSelectsActive() {
+        groupManager.addCameraGroup(name: "First")
+
+        XCTAssertNotNil(groupManager.activeGroupId)
+        XCTAssertEqual(groupManager.activeGroupId, groupManager.cameraGroups.first?.id)
+    }
+
+    func testAddSecondGroupDoesNotChangeActive() {
+        groupManager.addCameraGroup(name: "First")
+        let firstId = groupManager.activeGroupId
+
+        groupManager.addCameraGroup(name: "Second")
+
+        XCTAssertEqual(groupManager.activeGroupId, firstId)
+    }
+
+    // MARK: - Remove Group
+
+    func testRemoveCameraGroup() {
+        groupManager.addCameraGroup(name: "ToRemove")
+        let group = groupManager.cameraGroups.first!
+
+        groupManager.removeCameraGroup(group)
+
+        XCTAssertTrue(groupManager.cameraGroups.isEmpty)
+    }
+
+    func testRemoveActiveGroupSelectsAnother() {
+        groupManager.addCameraGroup(name: "First")
+        groupManager.addCameraGroup(name: "Second")
+        let first = groupManager.cameraGroups[0]
+
+        groupManager.setActiveGroup(first)
+        groupManager.removeCameraGroup(first)
+
+        XCTAssertEqual(groupManager.cameraGroups.count, 1)
+        XCTAssertEqual(groupManager.activeGroupId, groupManager.cameraGroups.first?.id)
+    }
+
+    // MARK: - Active Group
+
+    func testSetActiveGroup() {
+        groupManager.addCameraGroup(name: "A")
+        groupManager.addCameraGroup(name: "B")
+        let groupB = groupManager.cameraGroups[1]
+
+        groupManager.setActiveGroup(groupB)
+
+        XCTAssertEqual(groupManager.activeGroupId, groupB.id)
+        XCTAssertEqual(groupManager.activeGroup?.name, "B")
+    }
+
+    func testSetActiveGroupNil() {
+        groupManager.addCameraGroup(name: "A")
+        groupManager.setActiveGroup(nil)
+
+        XCTAssertNil(groupManager.activeGroupId)
+        XCTAssertNil(groupManager.activeGroup)
+    }
+
+    // MARK: - Camera Management
+
+    func testAddCameraToGroup() {
+        groupManager.addCameraGroup(name: "Test")
+        let group = groupManager.cameraGroups.first!
+
+        groupManager.addCameraToGroup("GP12345", group: group)
+
+        let updated = groupManager.cameraGroups.first!
+        XCTAssertTrue(updated.cameraSerials.contains("GP12345"))
+    }
+
+    func testRemoveCameraFromGroup() {
+        groupManager.addCameraGroup(name: "Test")
+        var group = groupManager.cameraGroups.first!
+        groupManager.addCameraToGroup("GP12345", group: group)
+
+        group = groupManager.cameraGroups.first!
+        groupManager.removeCameraFromGroup("GP12345", group: group)
+
+        let updated = groupManager.cameraGroups.first!
+        XCTAssertFalse(updated.cameraSerials.contains("GP12345"))
+    }
+
+    func testAddDuplicateCameraIsIdempotent() {
+        groupManager.addCameraGroup(name: "Test")
+        let group = groupManager.cameraGroups.first!
+
+        groupManager.addCameraToGroup("GP001", group: group)
+        let afterFirst = groupManager.cameraGroups.first!
+        groupManager.addCameraToGroup("GP001", group: afterFirst)
+
+        let updated = groupManager.cameraGroups.first!
+        XCTAssertEqual(updated.cameraSerials.count, 1)
+    }
+
+    // MARK: - Update Group
+
+    func testUpdateCameraGroup() {
+        groupManager.addCameraGroup(name: "Original")
+        var group = groupManager.cameraGroups.first!
+        group.name = "Updated"
+
+        groupManager.updateCameraGroup(group)
+
+        XCTAssertEqual(groupManager.cameraGroups.first?.name, "Updated")
+    }
+
+    // MARK: - CameraStatus
+
+    func testCameraStatusRawValues() {
+        XCTAssertEqual(CameraStatus.ready.rawValue, "Ready")
+        XCTAssertEqual(CameraStatus.error.rawValue, "Error")
+        XCTAssertEqual(CameraStatus.disconnected.rawValue, "Disconnected")
+    }
+}

--- a/FacettTests/CameraSettingDescriptionTests.swift
+++ b/FacettTests/CameraSettingDescriptionTests.swift
@@ -1,0 +1,91 @@
+import XCTest
+@testable import Facett
+
+final class CameraSettingDescriptionTests: XCTestCase {
+
+    // MARK: - Resolution
+
+    func testResolutionKnownValues() {
+        XCTAssertEqual(CameraSettingDescriptions.resolutionDescription(for: 1), "4K")
+        XCTAssertEqual(CameraSettingDescriptions.resolutionDescription(for: 9), "1080")
+        XCTAssertEqual(CameraSettingDescriptions.resolutionDescription(for: 100), "5.3K")
+    }
+
+    func testResolutionUnknownValue() {
+        XCTAssertEqual(CameraSettingDescriptions.resolutionDescription(for: 999), "Unknown")
+    }
+
+    // MARK: - FPS
+
+    func testFPSKnownValues() {
+        XCTAssertEqual(CameraSettingDescriptions.fpsDescription(for: 0), "240.0")
+        XCTAssertEqual(CameraSettingDescriptions.fpsDescription(for: 5), "60.0")
+        XCTAssertEqual(CameraSettingDescriptions.fpsDescription(for: 8), "30.0")
+        XCTAssertEqual(CameraSettingDescriptions.fpsDescription(for: 10), "24.0")
+    }
+
+    func testFPSUnknownValue() {
+        XCTAssertEqual(CameraSettingDescriptions.fpsDescription(for: -1), "Unknown")
+    }
+
+    // MARK: - Mode
+
+    func testModeKnownValues() {
+        XCTAssertEqual(CameraSettingDescriptions.modeDescription(for: 12), "Video")
+        XCTAssertEqual(CameraSettingDescriptions.modeDescription(for: 17), "Photo")
+    }
+
+    func testModeUnknownValue() {
+        XCTAssertEqual(CameraSettingDescriptions.modeDescription(for: 0), "Unknown")
+    }
+
+    // MARK: - Lens
+
+    func testLensKnownValues() {
+        XCTAssertEqual(CameraSettingDescriptions.lensDescription(for: 0), "Wide")
+        XCTAssertEqual(CameraSettingDescriptions.lensDescription(for: 4), "Linear")
+    }
+
+    func testLensUnknownValue() {
+        XCTAssertEqual(CameraSettingDescriptions.lensDescription(for: 99), "Unknown")
+    }
+
+    // MARK: - Hypersmooth
+
+    func testHypersmoothKnownValues() {
+        XCTAssertEqual(CameraSettingDescriptions.hypersmoothDescription(for: 0), "Off")
+        XCTAssertEqual(CameraSettingDescriptions.hypersmoothDescription(for: 1), "Low")
+        XCTAssertEqual(CameraSettingDescriptions.hypersmoothDescription(for: 2), "High")
+        XCTAssertEqual(CameraSettingDescriptions.hypersmoothDescription(for: 3), "Boost")
+    }
+
+    // MARK: - White Balance
+
+    func testWhiteBalanceKnownValues() {
+        XCTAssertEqual(CameraSettingDescriptions.whiteBalanceDescription(for: 0), "Auto")
+        XCTAssertEqual(CameraSettingDescriptions.whiteBalanceDescription(for: 5), "4000K")
+    }
+
+    // MARK: - EV
+
+    func testEVKnownValues() {
+        XCTAssertEqual(CameraSettingDescriptions.evDescription(for: 4), "0.0")
+        XCTAssertEqual(CameraSettingDescriptions.evDescription(for: 8), "-2.0")
+        XCTAssertEqual(CameraSettingDescriptions.evDescription(for: 0), "2.0")
+    }
+
+    // MARK: - Anti-Flicker
+
+    func testAntiFlickerKnownValues() {
+        XCTAssertEqual(CameraSettingDescriptions.antiFlickerDescription(for: 2), "60Hz")
+        XCTAssertEqual(CameraSettingDescriptions.antiFlickerDescription(for: 3), "50Hz")
+    }
+
+    // MARK: - Auto Power Down
+
+    func testAutoPowerDownKnownValues() {
+        XCTAssertEqual(CameraSettingDescriptions.autoPowerDownDescription(for: 0), "Never")
+        XCTAssertEqual(CameraSettingDescriptions.autoPowerDownDescription(for: 4), "5 Min")
+        XCTAssertEqual(CameraSettingDescriptions.autoPowerDownDescription(for: 6), "15 Min")
+    }
+}

--- a/FacettTests/ErrorHandlerTests.swift
+++ b/FacettTests/ErrorHandlerTests.swift
@@ -1,0 +1,76 @@
+import XCTest
+@testable import Facett
+
+final class ErrorHandlerTests: XCTestCase {
+
+    // MARK: - BLE Recovery Strategy
+
+    func testRecoveryStrategyForConnectionTimeout() {
+        let error = NSError(domain: "CBATTError", code: 7)
+        assertStrategy(ErrorHandler.shared.getBLERecoveryStrategy(for: error), .reconnectWithBackoff)
+    }
+
+    func testRecoveryStrategyForConnectionFailed() {
+        let error = NSError(domain: "CBATTError", code: 6)
+        assertStrategy(ErrorHandler.shared.getBLERecoveryStrategy(for: error), .resetAndRetry)
+    }
+
+    func testRecoveryStrategyForDisconnected() {
+        let error = NSError(domain: "CBATTError", code: 10)
+        assertStrategy(ErrorHandler.shared.getBLERecoveryStrategy(for: error), .reconnect)
+    }
+
+    func testRecoveryStrategyForAuthInsufficient() {
+        let error = NSError(domain: "CBATTError", code: 5)
+        assertStrategy(ErrorHandler.shared.getBLERecoveryStrategy(for: error), .reclaimControl)
+    }
+
+    func testRecoveryStrategyForAttributeNotFound() {
+        let error = NSError(domain: "CBATTError", code: 3)
+        assertStrategy(ErrorHandler.shared.getBLERecoveryStrategy(for: error), .rediscoverServices)
+    }
+
+    func testRecoveryStrategyForReadNotPermitted() {
+        let error = NSError(domain: "CBATTError", code: 2)
+        assertStrategy(ErrorHandler.shared.getBLERecoveryStrategy(for: error), .checkPermissions)
+    }
+
+    func testRecoveryStrategyForUnknownError() {
+        let error = NSError(domain: "CBATTError", code: 999)
+        assertStrategy(ErrorHandler.shared.getBLERecoveryStrategy(for: error), .none)
+    }
+
+    func testRecoveryStrategyForNonNSError() {
+        struct CustomError: Error {}
+        assertStrategy(ErrorHandler.shared.getBLERecoveryStrategy(for: CustomError()), .none)
+    }
+
+    // MARK: - BLE Recovery Strategy Descriptions
+
+    func testAllRecoveryStrategiesHaveDescriptions() {
+        let strategies: [BLERecoveryStrategy] = [
+            .none, .reconnect, .reconnectWithBackoff,
+            .resetAndRetry, .reclaimControl, .rediscoverServices, .checkPermissions
+        ]
+
+        for strategy in strategies {
+            XCTAssertFalse(strategy.description.isEmpty, "\(strategy) should have a description")
+        }
+    }
+
+    // MARK: - Execute with Recovery
+
+    func testExecuteWithRecoverySucceedsFirstAttempt() async throws {
+        let result: Int = try await ErrorHandler.shared.executeWithRecovery(
+            operation: "test", maxAttempts: 3, delay: 0.01
+        ) {
+            return 42 as Int
+        }
+
+        XCTAssertEqual(result, 42)
+    }
+}
+
+private func assertStrategy(_ actual: BLERecoveryStrategy, _ expected: BLERecoveryStrategy, file: StaticString = #file, line: UInt = #line) {
+    XCTAssertEqual(actual.description, expected.description, file: file, line: line)
+}


### PR DESCRIPTION
## Summary
- **CameraSettingDescriptionTests** (13 tests): Resolution, FPS, mode, lens, hypersmooth, white balance, EV, anti-flicker, auto power down — known values + unknown/edge cases
- **ErrorHandlerTests** (10 tests): BLE recovery strategy selection for all error codes (timeout, failed, disconnected, auth, attribute, permissions, unknown, non-NSError), strategy descriptions, async recovery execution
- **CameraGroupTests** (14 tests): Model init, Codable round-trip, group CRUD (add/remove/update), active group auto-selection, camera serial management (add/remove/idempotent), CameraStatus raw values

Also adds the 3 new suites to CI and removes an invalid SwiftLint config key.

## Test plan
- [x] All 37 new tests pass locally
- [x] All existing tests still pass
- [x] SwiftLint clean on new files
- [ ] CI passes

Fixes #55

Made with [Cursor](https://cursor.com)